### PR TITLE
Add at(blockNumber, args) to createProposal

### DIFF
--- a/back/node_watcher/src/tasks/createProposal.ts
+++ b/back/node_watcher/src/tasks/createProposal.ts
@@ -46,8 +46,14 @@ const createProposal: Task<NomidotProposal[]> = {
           // proposals should be unique
           if (proposalExists) return null;
 
-          const depositOf = await api.query.democracy.depositOf(proposalId);
-          const preImageRaw = await api.query.democracy.preimages(preImageHash);
+          const depositOf = await api.query.democracy.depositOf.at(
+            blockHash,
+            proposalId
+          );
+          const preImageRaw = await api.query.democracy.preimages.at(
+            blockHash,
+            preImageHash
+          );
           const preImage = preImageRaw.unwrapOr(null);
 
           if (!preImage) {


### PR DESCRIPTION
I totally missed that somehow.

It seems that I only tested with an archive node that doesn't have tabled Proposals. This causes the `depositInfo` to be undefined for any proposal that was tabled. 