### PR TITLE
Add Proposal status update

### DIFF
--- a/back/node_watcher/datamodel.prisma
+++ b/back/node_watcher/datamodel.prisma
@@ -72,7 +72,7 @@ type Proposal {
   preimage: Preimage @relation(name: "PreimageForProposal")
   preimageHash: String!
   proposalId: Int! @unique
-  proposalStatus: ProposalStatus! @relation(name: "ProposalStatusFromProposal")
+  proposalStatus: [ProposalStatus]! @relation(name: "ProposalStatusFromProposal")
 }
 
 type ProposalStatus {

--- a/back/node_watcher/src/generated/prisma-client/index.ts
+++ b/back/node_watcher/src/generated/prisma-client/index.ts
@@ -676,6 +676,12 @@ export type NominationOrderByInput =
   | "bonded_ASC"
   | "bonded_DESC";
 
+export type ProposalStatusOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "status_ASC"
+  | "status_DESC";
+
 export type PreimageArgumentOrderByInput =
   | "id_ASC"
   | "id_DESC"
@@ -717,12 +723,6 @@ export type ProposalOrderByInput =
   | "preimageHash_DESC"
   | "proposalId_ASC"
   | "proposalId_DESC";
-
-export type ProposalStatusOrderByInput =
-  | "id_ASC"
-  | "id_DESC"
-  | "status_ASC"
-  | "status_DESC";
 
 export type RewardOrderByInput =
   | "id_ASC"
@@ -1014,7 +1014,7 @@ export type PreimageWhereUniqueInput = AtLeastOne<{
   id: Maybe<ID_Input>;
 }>;
 
-export interface PreimageArgumentWhereInput {
+export interface ProposalStatusWhereInput {
   id?: Maybe<ID_Input>;
   id_not?: Maybe<ID_Input>;
   id_in?: Maybe<ID_Input[] | ID_Input>;
@@ -1029,38 +1029,93 @@ export interface PreimageArgumentWhereInput {
   id_not_starts_with?: Maybe<ID_Input>;
   id_ends_with?: Maybe<ID_Input>;
   id_not_ends_with?: Maybe<ID_Input>;
-  name?: Maybe<String>;
-  name_not?: Maybe<String>;
-  name_in?: Maybe<String[] | String>;
-  name_not_in?: Maybe<String[] | String>;
-  name_lt?: Maybe<String>;
-  name_lte?: Maybe<String>;
-  name_gt?: Maybe<String>;
-  name_gte?: Maybe<String>;
-  name_contains?: Maybe<String>;
-  name_not_contains?: Maybe<String>;
-  name_starts_with?: Maybe<String>;
-  name_not_starts_with?: Maybe<String>;
-  name_ends_with?: Maybe<String>;
-  name_not_ends_with?: Maybe<String>;
+  blockNumber?: Maybe<BlockNumberWhereInput>;
+  proposal?: Maybe<ProposalWhereInput>;
+  status?: Maybe<String>;
+  status_not?: Maybe<String>;
+  status_in?: Maybe<String[] | String>;
+  status_not_in?: Maybe<String[] | String>;
+  status_lt?: Maybe<String>;
+  status_lte?: Maybe<String>;
+  status_gt?: Maybe<String>;
+  status_gte?: Maybe<String>;
+  status_contains?: Maybe<String>;
+  status_not_contains?: Maybe<String>;
+  status_starts_with?: Maybe<String>;
+  status_not_starts_with?: Maybe<String>;
+  status_ends_with?: Maybe<String>;
+  status_not_ends_with?: Maybe<String>;
+  AND?: Maybe<ProposalStatusWhereInput[] | ProposalStatusWhereInput>;
+  OR?: Maybe<ProposalStatusWhereInput[] | ProposalStatusWhereInput>;
+  NOT?: Maybe<ProposalStatusWhereInput[] | ProposalStatusWhereInput>;
+}
+
+export interface ProposalWhereInput {
+  id?: Maybe<Int>;
+  id_not?: Maybe<Int>;
+  id_in?: Maybe<Int[] | Int>;
+  id_not_in?: Maybe<Int[] | Int>;
+  id_lt?: Maybe<Int>;
+  id_lte?: Maybe<Int>;
+  id_gt?: Maybe<Int>;
+  id_gte?: Maybe<Int>;
+  author?: Maybe<String>;
+  author_not?: Maybe<String>;
+  author_in?: Maybe<String[] | String>;
+  author_not_in?: Maybe<String[] | String>;
+  author_lt?: Maybe<String>;
+  author_lte?: Maybe<String>;
+  author_gt?: Maybe<String>;
+  author_gte?: Maybe<String>;
+  author_contains?: Maybe<String>;
+  author_not_contains?: Maybe<String>;
+  author_starts_with?: Maybe<String>;
+  author_not_starts_with?: Maybe<String>;
+  author_ends_with?: Maybe<String>;
+  author_not_ends_with?: Maybe<String>;
+  depositAmount?: Maybe<String>;
+  depositAmount_not?: Maybe<String>;
+  depositAmount_in?: Maybe<String[] | String>;
+  depositAmount_not_in?: Maybe<String[] | String>;
+  depositAmount_lt?: Maybe<String>;
+  depositAmount_lte?: Maybe<String>;
+  depositAmount_gt?: Maybe<String>;
+  depositAmount_gte?: Maybe<String>;
+  depositAmount_contains?: Maybe<String>;
+  depositAmount_not_contains?: Maybe<String>;
+  depositAmount_starts_with?: Maybe<String>;
+  depositAmount_not_starts_with?: Maybe<String>;
+  depositAmount_ends_with?: Maybe<String>;
+  depositAmount_not_ends_with?: Maybe<String>;
   preimage?: Maybe<PreimageWhereInput>;
-  value?: Maybe<String>;
-  value_not?: Maybe<String>;
-  value_in?: Maybe<String[] | String>;
-  value_not_in?: Maybe<String[] | String>;
-  value_lt?: Maybe<String>;
-  value_lte?: Maybe<String>;
-  value_gt?: Maybe<String>;
-  value_gte?: Maybe<String>;
-  value_contains?: Maybe<String>;
-  value_not_contains?: Maybe<String>;
-  value_starts_with?: Maybe<String>;
-  value_not_starts_with?: Maybe<String>;
-  value_ends_with?: Maybe<String>;
-  value_not_ends_with?: Maybe<String>;
-  AND?: Maybe<PreimageArgumentWhereInput[] | PreimageArgumentWhereInput>;
-  OR?: Maybe<PreimageArgumentWhereInput[] | PreimageArgumentWhereInput>;
-  NOT?: Maybe<PreimageArgumentWhereInput[] | PreimageArgumentWhereInput>;
+  preimageHash?: Maybe<String>;
+  preimageHash_not?: Maybe<String>;
+  preimageHash_in?: Maybe<String[] | String>;
+  preimageHash_not_in?: Maybe<String[] | String>;
+  preimageHash_lt?: Maybe<String>;
+  preimageHash_lte?: Maybe<String>;
+  preimageHash_gt?: Maybe<String>;
+  preimageHash_gte?: Maybe<String>;
+  preimageHash_contains?: Maybe<String>;
+  preimageHash_not_contains?: Maybe<String>;
+  preimageHash_starts_with?: Maybe<String>;
+  preimageHash_not_starts_with?: Maybe<String>;
+  preimageHash_ends_with?: Maybe<String>;
+  preimageHash_not_ends_with?: Maybe<String>;
+  proposalId?: Maybe<Int>;
+  proposalId_not?: Maybe<Int>;
+  proposalId_in?: Maybe<Int[] | Int>;
+  proposalId_not_in?: Maybe<Int[] | Int>;
+  proposalId_lt?: Maybe<Int>;
+  proposalId_lte?: Maybe<Int>;
+  proposalId_gt?: Maybe<Int>;
+  proposalId_gte?: Maybe<Int>;
+  proposalStatus_every?: Maybe<ProposalStatusWhereInput>;
+  proposalStatus_some?: Maybe<ProposalStatusWhereInput>;
+  proposalStatus_none?: Maybe<ProposalStatusWhereInput>;
+  AND?: Maybe<ProposalWhereInput[] | ProposalWhereInput>;
+  OR?: Maybe<ProposalWhereInput[] | ProposalWhereInput>;
+  NOT?: Maybe<ProposalWhereInput[] | ProposalWhereInput>;
 }
 
 export interface PreimageWhereInput {
@@ -1174,73 +1229,7 @@ export interface PreimageWhereInput {
   NOT?: Maybe<PreimageWhereInput[] | PreimageWhereInput>;
 }
 
-export interface ProposalWhereInput {
-  id?: Maybe<Int>;
-  id_not?: Maybe<Int>;
-  id_in?: Maybe<Int[] | Int>;
-  id_not_in?: Maybe<Int[] | Int>;
-  id_lt?: Maybe<Int>;
-  id_lte?: Maybe<Int>;
-  id_gt?: Maybe<Int>;
-  id_gte?: Maybe<Int>;
-  author?: Maybe<String>;
-  author_not?: Maybe<String>;
-  author_in?: Maybe<String[] | String>;
-  author_not_in?: Maybe<String[] | String>;
-  author_lt?: Maybe<String>;
-  author_lte?: Maybe<String>;
-  author_gt?: Maybe<String>;
-  author_gte?: Maybe<String>;
-  author_contains?: Maybe<String>;
-  author_not_contains?: Maybe<String>;
-  author_starts_with?: Maybe<String>;
-  author_not_starts_with?: Maybe<String>;
-  author_ends_with?: Maybe<String>;
-  author_not_ends_with?: Maybe<String>;
-  depositAmount?: Maybe<String>;
-  depositAmount_not?: Maybe<String>;
-  depositAmount_in?: Maybe<String[] | String>;
-  depositAmount_not_in?: Maybe<String[] | String>;
-  depositAmount_lt?: Maybe<String>;
-  depositAmount_lte?: Maybe<String>;
-  depositAmount_gt?: Maybe<String>;
-  depositAmount_gte?: Maybe<String>;
-  depositAmount_contains?: Maybe<String>;
-  depositAmount_not_contains?: Maybe<String>;
-  depositAmount_starts_with?: Maybe<String>;
-  depositAmount_not_starts_with?: Maybe<String>;
-  depositAmount_ends_with?: Maybe<String>;
-  depositAmount_not_ends_with?: Maybe<String>;
-  preimage?: Maybe<PreimageWhereInput>;
-  preimageHash?: Maybe<String>;
-  preimageHash_not?: Maybe<String>;
-  preimageHash_in?: Maybe<String[] | String>;
-  preimageHash_not_in?: Maybe<String[] | String>;
-  preimageHash_lt?: Maybe<String>;
-  preimageHash_lte?: Maybe<String>;
-  preimageHash_gt?: Maybe<String>;
-  preimageHash_gte?: Maybe<String>;
-  preimageHash_contains?: Maybe<String>;
-  preimageHash_not_contains?: Maybe<String>;
-  preimageHash_starts_with?: Maybe<String>;
-  preimageHash_not_starts_with?: Maybe<String>;
-  preimageHash_ends_with?: Maybe<String>;
-  preimageHash_not_ends_with?: Maybe<String>;
-  proposalId?: Maybe<Int>;
-  proposalId_not?: Maybe<Int>;
-  proposalId_in?: Maybe<Int[] | Int>;
-  proposalId_not_in?: Maybe<Int[] | Int>;
-  proposalId_lt?: Maybe<Int>;
-  proposalId_lte?: Maybe<Int>;
-  proposalId_gt?: Maybe<Int>;
-  proposalId_gte?: Maybe<Int>;
-  proposalStatus?: Maybe<ProposalStatusWhereInput>;
-  AND?: Maybe<ProposalWhereInput[] | ProposalWhereInput>;
-  OR?: Maybe<ProposalWhereInput[] | ProposalWhereInput>;
-  NOT?: Maybe<ProposalWhereInput[] | ProposalWhereInput>;
-}
-
-export interface ProposalStatusWhereInput {
+export interface PreimageArgumentWhereInput {
   id?: Maybe<ID_Input>;
   id_not?: Maybe<ID_Input>;
   id_in?: Maybe<ID_Input[] | ID_Input>;
@@ -1255,25 +1244,38 @@ export interface ProposalStatusWhereInput {
   id_not_starts_with?: Maybe<ID_Input>;
   id_ends_with?: Maybe<ID_Input>;
   id_not_ends_with?: Maybe<ID_Input>;
-  blockNumber?: Maybe<BlockNumberWhereInput>;
-  proposal?: Maybe<ProposalWhereInput>;
-  status?: Maybe<String>;
-  status_not?: Maybe<String>;
-  status_in?: Maybe<String[] | String>;
-  status_not_in?: Maybe<String[] | String>;
-  status_lt?: Maybe<String>;
-  status_lte?: Maybe<String>;
-  status_gt?: Maybe<String>;
-  status_gte?: Maybe<String>;
-  status_contains?: Maybe<String>;
-  status_not_contains?: Maybe<String>;
-  status_starts_with?: Maybe<String>;
-  status_not_starts_with?: Maybe<String>;
-  status_ends_with?: Maybe<String>;
-  status_not_ends_with?: Maybe<String>;
-  AND?: Maybe<ProposalStatusWhereInput[] | ProposalStatusWhereInput>;
-  OR?: Maybe<ProposalStatusWhereInput[] | ProposalStatusWhereInput>;
-  NOT?: Maybe<ProposalStatusWhereInput[] | ProposalStatusWhereInput>;
+  name?: Maybe<String>;
+  name_not?: Maybe<String>;
+  name_in?: Maybe<String[] | String>;
+  name_not_in?: Maybe<String[] | String>;
+  name_lt?: Maybe<String>;
+  name_lte?: Maybe<String>;
+  name_gt?: Maybe<String>;
+  name_gte?: Maybe<String>;
+  name_contains?: Maybe<String>;
+  name_not_contains?: Maybe<String>;
+  name_starts_with?: Maybe<String>;
+  name_not_starts_with?: Maybe<String>;
+  name_ends_with?: Maybe<String>;
+  name_not_ends_with?: Maybe<String>;
+  preimage?: Maybe<PreimageWhereInput>;
+  value?: Maybe<String>;
+  value_not?: Maybe<String>;
+  value_in?: Maybe<String[] | String>;
+  value_not_in?: Maybe<String[] | String>;
+  value_lt?: Maybe<String>;
+  value_lte?: Maybe<String>;
+  value_gt?: Maybe<String>;
+  value_gte?: Maybe<String>;
+  value_contains?: Maybe<String>;
+  value_not_contains?: Maybe<String>;
+  value_starts_with?: Maybe<String>;
+  value_not_starts_with?: Maybe<String>;
+  value_ends_with?: Maybe<String>;
+  value_not_ends_with?: Maybe<String>;
+  AND?: Maybe<PreimageArgumentWhereInput[] | PreimageArgumentWhereInput>;
+  OR?: Maybe<PreimageArgumentWhereInput[] | PreimageArgumentWhereInput>;
+  NOT?: Maybe<PreimageArgumentWhereInput[] | PreimageArgumentWhereInput>;
 }
 
 export interface PreimageStatusWhereInput {
@@ -1725,12 +1727,17 @@ export interface ProposalCreateWithoutPreimageInput {
   depositAmount: String;
   preimageHash: String;
   proposalId: Int;
-  proposalStatus: ProposalStatusCreateOneWithoutProposalInput;
+  proposalStatus?: Maybe<ProposalStatusCreateManyWithoutProposalInput>;
 }
 
-export interface ProposalStatusCreateOneWithoutProposalInput {
-  create?: Maybe<ProposalStatusCreateWithoutProposalInput>;
-  connect?: Maybe<ProposalStatusWhereUniqueInput>;
+export interface ProposalStatusCreateManyWithoutProposalInput {
+  create?: Maybe<
+    | ProposalStatusCreateWithoutProposalInput[]
+    | ProposalStatusCreateWithoutProposalInput
+  >;
+  connect?: Maybe<
+    ProposalStatusWhereUniqueInput[] | ProposalStatusWhereUniqueInput
+  >;
 }
 
 export interface ProposalStatusCreateWithoutProposalInput {
@@ -1797,14 +1804,46 @@ export interface ProposalUpdateWithoutPreimageDataInput {
   depositAmount?: Maybe<String>;
   preimageHash?: Maybe<String>;
   proposalId?: Maybe<Int>;
-  proposalStatus?: Maybe<ProposalStatusUpdateOneRequiredWithoutProposalInput>;
+  proposalStatus?: Maybe<ProposalStatusUpdateManyWithoutProposalInput>;
 }
 
-export interface ProposalStatusUpdateOneRequiredWithoutProposalInput {
-  create?: Maybe<ProposalStatusCreateWithoutProposalInput>;
-  update?: Maybe<ProposalStatusUpdateWithoutProposalDataInput>;
-  upsert?: Maybe<ProposalStatusUpsertWithoutProposalInput>;
-  connect?: Maybe<ProposalStatusWhereUniqueInput>;
+export interface ProposalStatusUpdateManyWithoutProposalInput {
+  create?: Maybe<
+    | ProposalStatusCreateWithoutProposalInput[]
+    | ProposalStatusCreateWithoutProposalInput
+  >;
+  delete?: Maybe<
+    ProposalStatusWhereUniqueInput[] | ProposalStatusWhereUniqueInput
+  >;
+  connect?: Maybe<
+    ProposalStatusWhereUniqueInput[] | ProposalStatusWhereUniqueInput
+  >;
+  set?: Maybe<
+    ProposalStatusWhereUniqueInput[] | ProposalStatusWhereUniqueInput
+  >;
+  disconnect?: Maybe<
+    ProposalStatusWhereUniqueInput[] | ProposalStatusWhereUniqueInput
+  >;
+  update?: Maybe<
+    | ProposalStatusUpdateWithWhereUniqueWithoutProposalInput[]
+    | ProposalStatusUpdateWithWhereUniqueWithoutProposalInput
+  >;
+  upsert?: Maybe<
+    | ProposalStatusUpsertWithWhereUniqueWithoutProposalInput[]
+    | ProposalStatusUpsertWithWhereUniqueWithoutProposalInput
+  >;
+  deleteMany?: Maybe<
+    ProposalStatusScalarWhereInput[] | ProposalStatusScalarWhereInput
+  >;
+  updateMany?: Maybe<
+    | ProposalStatusUpdateManyWithWhereNestedInput[]
+    | ProposalStatusUpdateManyWithWhereNestedInput
+  >;
+}
+
+export interface ProposalStatusUpdateWithWhereUniqueWithoutProposalInput {
+  where: ProposalStatusWhereUniqueInput;
+  data: ProposalStatusUpdateWithoutProposalDataInput;
 }
 
 export interface ProposalStatusUpdateWithoutProposalDataInput {
@@ -1812,9 +1851,57 @@ export interface ProposalStatusUpdateWithoutProposalDataInput {
   status?: Maybe<String>;
 }
 
-export interface ProposalStatusUpsertWithoutProposalInput {
+export interface ProposalStatusUpsertWithWhereUniqueWithoutProposalInput {
+  where: ProposalStatusWhereUniqueInput;
   update: ProposalStatusUpdateWithoutProposalDataInput;
   create: ProposalStatusCreateWithoutProposalInput;
+}
+
+export interface ProposalStatusScalarWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  status?: Maybe<String>;
+  status_not?: Maybe<String>;
+  status_in?: Maybe<String[] | String>;
+  status_not_in?: Maybe<String[] | String>;
+  status_lt?: Maybe<String>;
+  status_lte?: Maybe<String>;
+  status_gt?: Maybe<String>;
+  status_gte?: Maybe<String>;
+  status_contains?: Maybe<String>;
+  status_not_contains?: Maybe<String>;
+  status_starts_with?: Maybe<String>;
+  status_not_starts_with?: Maybe<String>;
+  status_ends_with?: Maybe<String>;
+  status_not_ends_with?: Maybe<String>;
+  AND?: Maybe<
+    ProposalStatusScalarWhereInput[] | ProposalStatusScalarWhereInput
+  >;
+  OR?: Maybe<ProposalStatusScalarWhereInput[] | ProposalStatusScalarWhereInput>;
+  NOT?: Maybe<
+    ProposalStatusScalarWhereInput[] | ProposalStatusScalarWhereInput
+  >;
+}
+
+export interface ProposalStatusUpdateManyWithWhereNestedInput {
+  where: ProposalStatusScalarWhereInput;
+  data: ProposalStatusUpdateManyDataInput;
+}
+
+export interface ProposalStatusUpdateManyDataInput {
+  status?: Maybe<String>;
 }
 
 export interface ProposalUpsertWithoutPreimageInput {
@@ -2163,7 +2250,7 @@ export interface ProposalCreateInput {
   preimage?: Maybe<PreimageCreateOneWithoutProposalInput>;
   preimageHash: String;
   proposalId: Int;
-  proposalStatus: ProposalStatusCreateOneWithoutProposalInput;
+  proposalStatus?: Maybe<ProposalStatusCreateManyWithoutProposalInput>;
 }
 
 export interface PreimageCreateOneWithoutProposalInput {
@@ -2189,7 +2276,7 @@ export interface ProposalUpdateInput {
   preimage?: Maybe<PreimageUpdateOneWithoutProposalInput>;
   preimageHash?: Maybe<String>;
   proposalId?: Maybe<Int>;
-  proposalStatus?: Maybe<ProposalStatusUpdateOneRequiredWithoutProposalInput>;
+  proposalStatus?: Maybe<ProposalStatusUpdateManyWithoutProposalInput>;
 }
 
 export interface PreimageUpdateOneWithoutProposalInput {
@@ -3047,7 +3134,15 @@ export interface ProposalPromise extends Promise<Proposal>, Fragmentable {
   preimage: <T = PreimagePromise>() => T;
   preimageHash: () => Promise<String>;
   proposalId: () => Promise<Int>;
-  proposalStatus: <T = ProposalStatusPromise>() => T;
+  proposalStatus: <T = FragmentableArray<ProposalStatus>>(args?: {
+    where?: ProposalStatusWhereInput;
+    orderBy?: ProposalStatusOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
 }
 
 export interface ProposalSubscription
@@ -3059,7 +3154,17 @@ export interface ProposalSubscription
   preimage: <T = PreimageSubscription>() => T;
   preimageHash: () => Promise<AsyncIterator<String>>;
   proposalId: () => Promise<AsyncIterator<Int>>;
-  proposalStatus: <T = ProposalStatusSubscription>() => T;
+  proposalStatus: <
+    T = Promise<AsyncIterator<ProposalStatusSubscription>>
+  >(args?: {
+    where?: ProposalStatusWhereInput;
+    orderBy?: ProposalStatusOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
 }
 
 export interface ProposalNullablePromise
@@ -3071,7 +3176,15 @@ export interface ProposalNullablePromise
   preimage: <T = PreimagePromise>() => T;
   preimageHash: () => Promise<String>;
   proposalId: () => Promise<Int>;
-  proposalStatus: <T = ProposalStatusPromise>() => T;
+  proposalStatus: <T = FragmentableArray<ProposalStatus>>(args?: {
+    where?: ProposalStatusWhereInput;
+    orderBy?: ProposalStatusOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
 }
 
 export interface ProposalStatus {

--- a/back/node_watcher/src/generated/prisma-client/prisma-schema.ts
+++ b/back/node_watcher/src/generated/prisma-client/prisma-schema.ts
@@ -1412,7 +1412,7 @@ type Proposal {
   preimage: Preimage
   preimageHash: String!
   proposalId: Int!
-  proposalStatus: ProposalStatus!
+  proposalStatus(where: ProposalStatusWhereInput, orderBy: ProposalStatusOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [ProposalStatus!]
 }
 
 type ProposalConnection {
@@ -1427,7 +1427,7 @@ input ProposalCreateInput {
   preimage: PreimageCreateOneWithoutProposalInput
   preimageHash: String!
   proposalId: Int!
-  proposalStatus: ProposalStatusCreateOneWithoutProposalInput!
+  proposalStatus: ProposalStatusCreateManyWithoutProposalInput
 }
 
 input ProposalCreateOneWithoutPreimageInput {
@@ -1445,7 +1445,7 @@ input ProposalCreateWithoutPreimageInput {
   depositAmount: String!
   preimageHash: String!
   proposalId: Int!
-  proposalStatus: ProposalStatusCreateOneWithoutProposalInput!
+  proposalStatus: ProposalStatusCreateManyWithoutProposalInput
 }
 
 input ProposalCreateWithoutProposalStatusInput {
@@ -1502,9 +1502,9 @@ input ProposalStatusCreateInput {
   status: String!
 }
 
-input ProposalStatusCreateOneWithoutProposalInput {
-  create: ProposalStatusCreateWithoutProposalInput
-  connect: ProposalStatusWhereUniqueInput
+input ProposalStatusCreateManyWithoutProposalInput {
+  create: [ProposalStatusCreateWithoutProposalInput!]
+  connect: [ProposalStatusWhereUniqueInput!]
 }
 
 input ProposalStatusCreateWithoutProposalInput {
@@ -1528,6 +1528,40 @@ enum ProposalStatusOrderByInput {
 type ProposalStatusPreviousValues {
   id: ID!
   status: String!
+}
+
+input ProposalStatusScalarWhereInput {
+  id: ID
+  id_not: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_gt: ID
+  id_gte: ID
+  id_contains: ID
+  id_not_contains: ID
+  id_starts_with: ID
+  id_not_starts_with: ID
+  id_ends_with: ID
+  id_not_ends_with: ID
+  status: String
+  status_not: String
+  status_in: [String!]
+  status_not_in: [String!]
+  status_lt: String
+  status_lte: String
+  status_gt: String
+  status_gte: String
+  status_contains: String
+  status_not_contains: String
+  status_starts_with: String
+  status_not_starts_with: String
+  status_ends_with: String
+  status_not_ends_with: String
+  AND: [ProposalStatusScalarWhereInput!]
+  OR: [ProposalStatusScalarWhereInput!]
+  NOT: [ProposalStatusScalarWhereInput!]
 }
 
 type ProposalStatusSubscriptionPayload {
@@ -1554,15 +1588,29 @@ input ProposalStatusUpdateInput {
   status: String
 }
 
+input ProposalStatusUpdateManyDataInput {
+  status: String
+}
+
 input ProposalStatusUpdateManyMutationInput {
   status: String
 }
 
-input ProposalStatusUpdateOneRequiredWithoutProposalInput {
-  create: ProposalStatusCreateWithoutProposalInput
-  update: ProposalStatusUpdateWithoutProposalDataInput
-  upsert: ProposalStatusUpsertWithoutProposalInput
-  connect: ProposalStatusWhereUniqueInput
+input ProposalStatusUpdateManyWithoutProposalInput {
+  create: [ProposalStatusCreateWithoutProposalInput!]
+  delete: [ProposalStatusWhereUniqueInput!]
+  connect: [ProposalStatusWhereUniqueInput!]
+  set: [ProposalStatusWhereUniqueInput!]
+  disconnect: [ProposalStatusWhereUniqueInput!]
+  update: [ProposalStatusUpdateWithWhereUniqueWithoutProposalInput!]
+  upsert: [ProposalStatusUpsertWithWhereUniqueWithoutProposalInput!]
+  deleteMany: [ProposalStatusScalarWhereInput!]
+  updateMany: [ProposalStatusUpdateManyWithWhereNestedInput!]
+}
+
+input ProposalStatusUpdateManyWithWhereNestedInput {
+  where: ProposalStatusScalarWhereInput!
+  data: ProposalStatusUpdateManyDataInput!
 }
 
 input ProposalStatusUpdateWithoutProposalDataInput {
@@ -1570,7 +1618,13 @@ input ProposalStatusUpdateWithoutProposalDataInput {
   status: String
 }
 
-input ProposalStatusUpsertWithoutProposalInput {
+input ProposalStatusUpdateWithWhereUniqueWithoutProposalInput {
+  where: ProposalStatusWhereUniqueInput!
+  data: ProposalStatusUpdateWithoutProposalDataInput!
+}
+
+input ProposalStatusUpsertWithWhereUniqueWithoutProposalInput {
+  where: ProposalStatusWhereUniqueInput!
   update: ProposalStatusUpdateWithoutProposalDataInput!
   create: ProposalStatusCreateWithoutProposalInput!
 }
@@ -1639,7 +1693,7 @@ input ProposalUpdateInput {
   preimage: PreimageUpdateOneWithoutProposalInput
   preimageHash: String
   proposalId: Int
-  proposalStatus: ProposalStatusUpdateOneRequiredWithoutProposalInput
+  proposalStatus: ProposalStatusUpdateManyWithoutProposalInput
 }
 
 input ProposalUpdateManyMutationInput {
@@ -1670,7 +1724,7 @@ input ProposalUpdateWithoutPreimageDataInput {
   depositAmount: String
   preimageHash: String
   proposalId: Int
-  proposalStatus: ProposalStatusUpdateOneRequiredWithoutProposalInput
+  proposalStatus: ProposalStatusUpdateManyWithoutProposalInput
 }
 
 input ProposalUpdateWithoutProposalStatusDataInput {
@@ -1751,7 +1805,9 @@ input ProposalWhereInput {
   proposalId_lte: Int
   proposalId_gt: Int
   proposalId_gte: Int
-  proposalStatus: ProposalStatusWhereInput
+  proposalStatus_every: ProposalStatusWhereInput
+  proposalStatus_some: ProposalStatusWhereInput
+  proposalStatus_none: ProposalStatusWhereInput
   AND: [ProposalWhereInput!]
   OR: [ProposalWhereInput!]
   NOT: [ProposalWhereInput!]

--- a/back/node_watcher/src/nodeWatcher.ts
+++ b/back/node_watcher/src/nodeWatcher.ts
@@ -8,8 +8,8 @@ import { logger } from '@polkadot/util';
 
 import { NomidotTask } from './tasks/types';
 
-// const ARCHIVE_NODE_ENDPOINT = 'wss://kusama-rpc.polkadot.io/';
-const ARCHIVE_NODE_ENDPOINT = 'ws://127.0.0.1:9944';
+const ARCHIVE_NODE_ENDPOINT = 'wss://kusama-rpc.polkadot.io/';
+// const ARCHIVE_NODE_ENDPOINT = 'ws://127.0.0.1:9944';
 
 const l = logger('node-watcher');
 

--- a/back/node_watcher/src/nodeWatcher.ts
+++ b/back/node_watcher/src/nodeWatcher.ts
@@ -8,8 +8,8 @@ import { logger } from '@polkadot/util';
 
 import { NomidotTask } from './tasks/types';
 
-const ARCHIVE_NODE_ENDPOINT = 'wss://kusama-rpc.polkadot.io/';
-// const ARCHIVE_NODE_ENDPOINT = 'ws://127.0.0.1:9944';
+// const ARCHIVE_NODE_ENDPOINT = 'wss://kusama-rpc.polkadot.io/';
+const ARCHIVE_NODE_ENDPOINT = 'ws://127.0.0.1:9944';
 
 const l = logger('node-watcher');
 

--- a/back/node_watcher/src/tasks/createProposal.ts
+++ b/back/node_watcher/src/tasks/createProposal.ts
@@ -36,7 +36,7 @@ const createProposal: Task<NomidotProposal[]> = {
 
     const proposalEvents = events.filter(
       ({ event: { method, section } }) =>
-        section === 'democracy' && method === 'Proposed'
+        section === 'democracy' && method === ProposalStatus.PROPOSED
     );
 
     const results: NomidotProposal[] = [];

--- a/back/node_watcher/src/tasks/createProposalStatus.ts
+++ b/back/node_watcher/src/tasks/createProposalStatus.ts
@@ -1,0 +1,107 @@
+// Copyright 2018-2020 @paritytech/nomidot authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { ApiPromise } from '@polkadot/api';
+import { BlockNumber, Hash } from '@polkadot/types/interfaces';
+import { logger } from '@polkadot/util';
+
+import { prisma } from '../generated/prisma-client';
+import {
+  NomidotProposalRawEvent,
+  NomidotProposalStatusUpdate,
+  ProposalStatus,
+  Task,
+} from './types';
+
+const l = logger('Task: Proposals Status Update');
+
+/*
+ *  ======= Table (Proposal Status Update) ======
+ */
+const createProposal: Task<NomidotProposalStatusUpdate[]> = {
+  name: 'createProposalStatusUpdate',
+  read: async (
+    blockHash: Hash,
+    api: ApiPromise
+  ): Promise<NomidotProposalStatusUpdate[]> => {
+    const events = await api.query.system.events.at(blockHash);
+
+    const proposalEvents = events.filter(
+      ({ event: { method, section } }) =>
+        section === 'democracy' && method === ProposalStatus.TABLED
+    );
+
+    const results: NomidotProposalStatusUpdate[] = [];
+
+    await Promise.all(
+      proposalEvents.map(async ({ event: { data, typeDef } }) => {
+        const proposalRawEvent: NomidotProposalRawEvent = data.reduce(
+          (prev, curr, index) => {
+            const type = typeDef[index].type;
+
+            return {
+              ...prev,
+              [type]: curr.toString(),
+            };
+          },
+          {}
+        );
+
+        if (!proposalRawEvent.PropIndex) {
+          l.error(
+            `Expected PropIndex not foung on the event: ${proposalRawEvent.PropIndex}`
+          );
+          return null;
+        }
+
+        const relatedProposal = await prisma.proposal({
+          proposalId: Number(proposalRawEvent.PropIndex),
+        });
+
+        if (!relatedProposal) {
+          l.error(
+            `No existing proposal found for Proposal id: ${proposalRawEvent.PropIndex}`
+          );
+          return null;
+        }
+
+        const result: NomidotProposalStatusUpdate = {
+          proposalId: Number(proposalRawEvent.PropIndex),
+          status: ProposalStatus.TABLED,
+        };
+
+        l.log(`Nomidot Proposal Status Update: ${JSON.stringify(result)}`);
+        results.push(result);
+      })
+    );
+
+    return results;
+  },
+  write: async (
+    blockNumber: BlockNumber,
+    value: NomidotProposalStatusUpdate[]
+  ) => {
+    await Promise.all(
+      value.map(async prop => {
+        const { proposalId: pId, status } = prop;
+
+        await prisma.createProposalStatus({
+          blockNumber: {
+            connect: {
+              number: blockNumber.toNumber(),
+            },
+          },
+          proposal: {
+            connect: {
+              proposalId: pId,
+            },
+          },
+          status,
+        });
+      })
+    );
+  },
+};
+
+export default createProposal;

--- a/back/node_watcher/src/tasks/index.ts
+++ b/back/node_watcher/src/tasks/index.ts
@@ -6,6 +6,7 @@ import createBlockNumber from './createBlockNumber';
 import createEra from './createEra';
 import createPreimage from './createPreimage';
 import createProposal from './createProposal';
+import createProposalStatus from './createProposalStatus';
 import createSession from './createSession';
 import createSlashing from './createSlashing';
 import createTotalIssuance from './createTotalIssuance';
@@ -22,4 +23,5 @@ export const nomidotTasks: NomidotTask[] = [
   createValidator,
   createPreimage,
   createProposal,
+  createProposalStatus,
 ];

--- a/back/node_watcher/src/tasks/types.ts
+++ b/back/node_watcher/src/tasks/types.ts
@@ -66,6 +66,7 @@ export type Nomidot =
   | NomidotEra
   | NomidotHeartBeat
   | NomidotPreimage[]
+  | NomidotProposalStatusUpdate[]
   | NomidotProposal[]
   | NomidotSession
   | NomidotSlashing[]
@@ -124,4 +125,9 @@ export interface NomidotPreimageRawEvent {
   Hash?: Hash;
   AccountId?: AccountId;
   Balance?: Balance;
+}
+
+export interface NomidotProposalStatusUpdate {
+  proposalId: number;
+  status: ProposalStatus;
 }


### PR DESCRIPTION
This adds a new proposal Status when a known proposal is updated.
This task effectively tracks `Tabled`  event, that is the only other event than `Proposed` (which is already handled in the `createProposal` task) according to https://polkadot.js.org/api/substrate/events.html#democracy

cc https://github.com/paritytech/polkassembly/issues/231