### PR TITLE
feat(#160) - minimize queries

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,8 +35,8 @@ module.exports = {
     'prettier/prettier': 'error',
     'simple-import-sort/sort': 'error',
     '@typescript-eslint/no-unused-vars': [
-      'warn',
-      { vars: 'all', args: 'after-used', ignoreRestSiblings: false },
+      'error',
+      { vars: 'all', args: 'after-used', ignoreRestSiblings: false, argsIgnorePattern: "^_"},
     ],
   },
   settings: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
     'prettier/prettier': 'error',
     'simple-import-sort/sort': 'error',
     '@typescript-eslint/no-unused-vars': [
-      'error',
+      'warn',
       { vars: 'all', args: 'after-used', ignoreRestSiblings: false },
     ],
   },

--- a/back/node_watcher/kubernetes/nomidotwatcher-job.yaml
+++ b/back/node_watcher/kubernetes/nomidotwatcher-job.yaml
@@ -1,13 +1,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: nomidotwatcher-109420
+  name: nomidotwatcher-160366
   namespace: nodewatcher-staging
   labels:
     stage: staging
     name: nomidotwatcher
     app: nomidotwatcher
-    job-name: nomidotwatcher-109420
+    job-name: nomidotwatcher-160366
 spec:
   manualSelector: true
   selector:
@@ -15,24 +15,23 @@ spec:
       stage: staging
       name: nomidotwatcher
       app: nomidotwatcher
-      job-name: nomidotwatcher-109420
+      job-name: nomidotwatcher-160366
   template:
     metadata:
       labels:
         stage: staging
         name: nomidotwatcher
         app: nomidotwatcher
-        job-name: nomidotwatcher-109420
+        job-name: nomidotwatcher-160366
     spec:
       restartPolicy: Never
       containers:
         - name: nomidotwatcher
-          image: eu.gcr.io/test-installations-222013/nomidot_watcher@sha256:d13d01e989ff22a44b53b77fb65240cc8572ab543f316e62f545f7f8c9c30046
+          image: eu.gcr.io/test-installations-222013/nomidot_watcher@sha256:9191c2a2d827ee10c80e1e2819df23c99d4fa75c2c4e52b5d2c6bbd214108538
           imagePullPolicy: Always
           env:
             - name: PRISMA_ENDPOINT
               value: http://10.0.9.43:4466
             - name: START_FROM
-              value: '109420'
+              value: '160366'
           command: ["yarn", "start"]
-  backoffLimit: 6

--- a/back/node_watcher/kubernetes/nomidotwatcher-last-50k-job.yaml
+++ b/back/node_watcher/kubernetes/nomidotwatcher-last-50k-job.yaml
@@ -27,12 +27,11 @@ spec:
       restartPolicy: Never
       containers:
         - name: nomidotwatcher
-          image: eu.gcr.io/test-installations-222013/nomidot_watcher@sha256:d13d01e989ff22a44b53b77fb65240cc8572ab543f316e62f545f7f8c9c30046
+          image: eu.gcr.io/test-installations-222013/nomidot_watcher@sha256:9191c2a2d827ee10c80e1e2819df23c99d4fa75c2c4e52b5d2c6bbd214108538
           imagePullPolicy: Always
           env:
             - name: PRISMA_ENDPOINT
               value: http://10.0.9.43:4466
             - name: START_FROM
-              value: '952660'
+              value: '980000'
           command: ["yarn", "start"]
-  backoffLimit: 6

--- a/back/node_watcher/src/nodeWatcher.ts
+++ b/back/node_watcher/src/nodeWatcher.ts
@@ -83,8 +83,8 @@ async function incrementor(
 
     const [events, sessionIndex] = await Promise.all([
       await api.query.system.events.at(blockHash),
-      await api.query.session.currentIndex.at(blockHash)
-    ])
+      await api.query.session.currentIndex.at(blockHash),
+    ]);
 
     const cached: Cached = {
       events,

--- a/back/node_watcher/src/nodeWatcher.ts
+++ b/back/node_watcher/src/nodeWatcher.ts
@@ -81,11 +81,13 @@ async function incrementor(
       api.registry.setMetadata(rpcMeta);
     }
 
+    const events = await api.query.system.events.at(blockHash);
+
     // execute watcher tasks
     for await (const task of tasks) {
       l.warn(`Task --- ${task.name}`);
 
-      const result = await task.read(blockHash, api);
+      const result = await task.read(blockHash, events, api);
 
       try {
         l.warn(`Writing: ${JSON.stringify(result)}`);

--- a/back/node_watcher/src/nodeWatcher.ts
+++ b/back/node_watcher/src/nodeWatcher.ts
@@ -81,8 +81,10 @@ async function incrementor(
       api.registry.setMetadata(rpcMeta);
     }
 
-    const events = await api.query.system.events.at(blockHash);
-    const sessionIndex = await api.query.session.currentIndex.at(blockHash);
+    const [events, sessionIndex] = await Promise.all([
+      await api.query.system.events.at(blockHash),
+      await api.query.session.currentIndex.at(blockHash)
+    ])
 
     const cached: Cached = {
       events,

--- a/back/node_watcher/src/nodeWatcher.ts
+++ b/back/node_watcher/src/nodeWatcher.ts
@@ -82,12 +82,13 @@ async function incrementor(
     }
 
     const events = await api.query.system.events.at(blockHash);
+    const sessionIndex = await api.query.session.currentIndex.at(blockHash);
 
     // execute watcher tasks
     for await (const task of tasks) {
       l.warn(`Task --- ${task.name}`);
 
-      const result = await task.read(blockHash, events, api);
+      const result = await task.read(blockHash, events, sessionIndex, api);
 
       try {
         l.warn(`Writing: ${JSON.stringify(result)}`);

--- a/back/node_watcher/src/tasks/createBlockNumber.ts
+++ b/back/node_watcher/src/tasks/createBlockNumber.ts
@@ -4,17 +4,11 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { createType } from '@polkadot/types';
-import {
-  BlockNumber,
-  EventRecord,
-  Hash,
-  Moment,
-  SessionIndex,
-} from '@polkadot/types/interfaces';
+import { BlockNumber, Hash, Moment } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { BlockNumberCreateInput, prisma } from '../generated/prisma-client';
-import { NomidotBlock, Task } from './types';
+import { Cached, NomidotBlock, Task } from './types';
 
 const l = logger('Task: BlockNumber');
 
@@ -25,8 +19,7 @@ const createBlockNumber: Task<NomidotBlock> = {
   name: 'createBlockNumber',
   read: async (
     blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
+    cached: Cached,
     api: ApiPromise
   ): Promise<NomidotBlock> => {
     const [author] = await api.derive.chain.getHeader(blockHash);

--- a/back/node_watcher/src/tasks/createBlockNumber.ts
+++ b/back/node_watcher/src/tasks/createBlockNumber.ts
@@ -4,7 +4,7 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { createType } from '@polkadot/types';
-import { BlockNumber, Hash, Moment } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, Moment } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { BlockNumberCreateInput, prisma } from '../generated/prisma-client';
@@ -17,7 +17,7 @@ const l = logger('Task: BlockNumber');
  */
 const createBlockNumber: Task<NomidotBlock> = {
   name: 'createBlockNumber',
-  read: async (blockHash: Hash, api: ApiPromise): Promise<NomidotBlock> => {
+  read: async (blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<NomidotBlock> => {
     const [author] = await api.derive.chain.getHeader(blockHash);
 
     const startDateTime: Moment = await api.query.timestamp.now.at(blockHash);

--- a/back/node_watcher/src/tasks/createBlockNumber.ts
+++ b/back/node_watcher/src/tasks/createBlockNumber.ts
@@ -4,7 +4,7 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { createType } from '@polkadot/types';
-import { BlockNumber, EventRecord, Hash, Moment } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, Moment, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { BlockNumberCreateInput, prisma } from '../generated/prisma-client';
@@ -17,7 +17,7 @@ const l = logger('Task: BlockNumber');
  */
 const createBlockNumber: Task<NomidotBlock> = {
   name: 'createBlockNumber',
-  read: async (blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<NomidotBlock> => {
+  read: async (blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<NomidotBlock> => {
     const [author] = await api.derive.chain.getHeader(blockHash);
 
     const startDateTime: Moment = await api.query.timestamp.now.at(blockHash);

--- a/back/node_watcher/src/tasks/createBlockNumber.ts
+++ b/back/node_watcher/src/tasks/createBlockNumber.ts
@@ -4,7 +4,13 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { createType } from '@polkadot/types';
-import { BlockNumber, EventRecord, Hash, Moment, SessionIndex } from '@polkadot/types/interfaces';
+import {
+  BlockNumber,
+  EventRecord,
+  Hash,
+  Moment,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { BlockNumberCreateInput, prisma } from '../generated/prisma-client';
@@ -17,7 +23,12 @@ const l = logger('Task: BlockNumber');
  */
 const createBlockNumber: Task<NomidotBlock> = {
   name: 'createBlockNumber',
-  read: async (blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<NomidotBlock> => {
+  read: async (
+    blockHash: Hash,
+    events: EventRecord[],
+    sessionIndex: SessionIndex,
+    api: ApiPromise
+  ): Promise<NomidotBlock> => {
     const [author] = await api.derive.chain.getHeader(blockHash);
 
     const startDateTime: Moment = await api.query.timestamp.now.at(blockHash);

--- a/back/node_watcher/src/tasks/createEra.ts
+++ b/back/node_watcher/src/tasks/createEra.ts
@@ -3,7 +3,12 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
+import {
+  BlockNumber,
+  EventRecord,
+  Hash,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -16,7 +21,12 @@ const l = logger('Task: Era');
  */
 const createEra: Task<NomidotEra> = {
   name: 'createEra',
-  read: async (blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<NomidotEra> => {
+  read: async (
+    blockHash: Hash,
+    events: EventRecord[],
+    sessionIndex: SessionIndex,
+    api: ApiPromise
+  ): Promise<NomidotEra> => {
     const idx = await api.query.staking.currentEra.at(blockHash);
     const points = await api.query.staking.currentEraPointsEarned.at(blockHash);
     const currentEraStartSessionIndex = await api.query.staking.currentEraStartSessionIndex.at(

--- a/back/node_watcher/src/tasks/createEra.ts
+++ b/back/node_watcher/src/tasks/createEra.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -16,7 +16,7 @@ const l = logger('Task: Era');
  */
 const createEra: Task<NomidotEra> = {
   name: 'createEra',
-  read: async (blockHash: Hash, api: ApiPromise): Promise<NomidotEra> => {
+  read: async (blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<NomidotEra> => {
     const idx = await api.query.staking.currentEra.at(blockHash);
     const points = await api.query.staking.currentEraPointsEarned.at(blockHash);
     const currentEraStartSessionIndex = await api.query.staking.currentEraStartSessionIndex.at(

--- a/back/node_watcher/src/tasks/createEra.ts
+++ b/back/node_watcher/src/tasks/createEra.ts
@@ -3,16 +3,11 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import {
-  BlockNumber,
-  EventRecord,
-  Hash,
-  SessionIndex,
-} from '@polkadot/types/interfaces';
+import { BlockNumber, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
-import { NomidotEra, Task } from './types';
+import { Cached, NomidotEra, Task } from './types';
 
 const l = logger('Task: Era');
 
@@ -23,8 +18,7 @@ const createEra: Task<NomidotEra> = {
   name: 'createEra',
   read: async (
     blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
+    _cached: Cached,
     api: ApiPromise
   ): Promise<NomidotEra> => {
     const idx = await api.query.staking.currentEra.at(blockHash);

--- a/back/node_watcher/src/tasks/createEra.ts
+++ b/back/node_watcher/src/tasks/createEra.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -16,7 +16,7 @@ const l = logger('Task: Era');
  */
 const createEra: Task<NomidotEra> = {
   name: 'createEra',
-  read: async (blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<NomidotEra> => {
+  read: async (blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<NomidotEra> => {
     const idx = await api.query.staking.currentEra.at(blockHash);
     const points = await api.query.staking.currentEraPointsEarned.at(blockHash);
     const currentEraStartSessionIndex = await api.query.staking.currentEraStartSessionIndex.at(

--- a/back/node_watcher/src/tasks/createHeartbeat.ts
+++ b/back/node_watcher/src/tasks/createHeartbeat.ts
@@ -21,7 +21,7 @@ const createHeartBeat: Task<NomidotHeartBeat[]> = {
     _blockHash: Hash,
     cached: Cached,
     _api: ApiPromise
-  ): NomidotHeartBeat[] => {
+  ): Promise<NomidotHeartBeat[]> => {
     const { events, sessionIndex } = cached;
 
     const heartbeatEvents: EventRecord[] = filterEvents(
@@ -45,7 +45,7 @@ const createHeartBeat: Task<NomidotHeartBeat[]> = {
 
     l.log(`Heartbeat: ${JSON.stringify(result)}`);
 
-    return result;
+    return Promise.resolve(result);
   },
   write: async (blockNumber: BlockNumber, heartbeats: NomidotHeartBeat[]) => {
     await Promise.all(

--- a/back/node_watcher/src/tasks/createHeartbeat.ts
+++ b/back/node_watcher/src/tasks/createHeartbeat.ts
@@ -23,10 +23,10 @@ const l = logger('Task: HeartBeat');
 const createHeartBeat: Task<NomidotHeartBeat[]> = {
   name: 'createHeartBeat',
   read: (
-    blockHash: Hash,
+    _blockHash: Hash,
     events: EventRecord[],
     sessionIndex: SessionIndex,
-    api: ApiPromise
+    _api: ApiPromise
   ): NomidotHeartBeat[] => {
     const heartbeatEvents: EventRecord[] = filterEvents(
       events,

--- a/back/node_watcher/src/tasks/createHeartbeat.ts
+++ b/back/node_watcher/src/tasks/createHeartbeat.ts
@@ -3,7 +3,12 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
+import {
+  BlockNumber,
+  EventRecord,
+  Hash,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -17,12 +22,12 @@ const l = logger('Task: HeartBeat');
  */
 const createHeartBeat: Task<NomidotHeartBeat[]> = {
   name: 'createHeartBeat',
-  read: async (
+  read: (
     blockHash: Hash,
     events: EventRecord[],
     sessionIndex: SessionIndex,
     api: ApiPromise
-  ): Promise<NomidotHeartBeat[]> => {
+  ): NomidotHeartBeat[] => {
     const heartbeatEvents: EventRecord[] = filterEvents(
       events,
       'imOnline',

--- a/back/node_watcher/src/tasks/createHeartbeat.ts
+++ b/back/node_watcher/src/tasks/createHeartbeat.ts
@@ -19,10 +19,9 @@ const createHeartBeat: Task<NomidotHeartBeat[]> = {
   name: 'createHeartBeat',
   read: async (
     blockHash: Hash,
+    events: EventRecord[],
     api: ApiPromise
   ): Promise<NomidotHeartBeat[]> => {
-    const events = await api.query.system.events.at(blockHash);
-
     const heartbeatEvents: EventRecord[] = filterEvents(
       events,
       'imOnline',

--- a/back/node_watcher/src/tasks/createHeartbeat.ts
+++ b/back/node_watcher/src/tasks/createHeartbeat.ts
@@ -3,17 +3,12 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import {
-  BlockNumber,
-  EventRecord,
-  Hash,
-  SessionIndex,
-} from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
 import { filterEvents } from '../util/filterEvents';
-import { NomidotHeartBeat, Task } from './types';
+import { Cached, NomidotHeartBeat, Task } from './types';
 
 const l = logger('Task: HeartBeat');
 
@@ -24,10 +19,11 @@ const createHeartBeat: Task<NomidotHeartBeat[]> = {
   name: 'createHeartBeat',
   read: (
     _blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
+    cached: Cached,
     _api: ApiPromise
   ): NomidotHeartBeat[] => {
+    const { events, sessionIndex } = cached;
+
     const heartbeatEvents: EventRecord[] = filterEvents(
       events,
       'imOnline',

--- a/back/node_watcher/src/tasks/createHeartbeat.ts
+++ b/back/node_watcher/src/tasks/createHeartbeat.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -20,6 +20,7 @@ const createHeartBeat: Task<NomidotHeartBeat[]> = {
   read: async (
     blockHash: Hash,
     events: EventRecord[],
+    sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotHeartBeat[]> => {
     const heartbeatEvents: EventRecord[] = filterEvents(
@@ -31,8 +32,6 @@ const createHeartBeat: Task<NomidotHeartBeat[]> = {
     const result: NomidotHeartBeat[] = [];
 
     if (heartbeatEvents) {
-      const sessionIndex = await api.query.session.currentIndex.at(blockHash);
-
       heartbeatEvents.map(({ event: { data } }) => {
         data.map(authorityId => {
           result.push({

--- a/back/node_watcher/src/tasks/createMotion.ts
+++ b/back/node_watcher/src/tasks/createMotion.ts
@@ -8,6 +8,7 @@ import { BlockNumber, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
+import { filterEvents } from '../util/filterEvents';
 import { motionStatus, preimageStatus } from '../util/statuses';
 import {
   NomidotArgument,
@@ -25,11 +26,8 @@ const createMotion: Task<NomidotMotion[]> = {
   name: 'createMotion',
   read: async (blockHash: Hash, api: ApiPromise): Promise<NomidotMotion[]> => {
     const events = await api.query.system.events.at(blockHash);
-
-    const motionEvents = events.filter(
-      ({ event: { method, section } }) =>
-        section === 'council' && method === motionStatus.PROPOSED
-    );
+    
+    const motionEvents = filterEvents(events, 'council', motionStatus.PROPOSED)
 
     const results: NomidotMotion[] = [];
 

--- a/back/node_watcher/src/tasks/createMotion.ts
+++ b/back/node_watcher/src/tasks/createMotion.ts
@@ -4,7 +4,7 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { GenericCall } from '@polkadot/types';
-import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -24,7 +24,7 @@ const l = logger('Task: Motions');
  */
 const createMotion: Task<NomidotMotion[]> = {
   name: 'createMotion',
-  read: async (blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<NomidotMotion[]> => {
+  read: async (blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<NomidotMotion[]> => {
     const motionEvents = filterEvents(events, 'council', motionStatus.PROPOSED)
 
     const results: NomidotMotion[] = [];

--- a/back/node_watcher/src/tasks/createMotion.ts
+++ b/back/node_watcher/src/tasks/createMotion.ts
@@ -4,7 +4,7 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { GenericCall } from '@polkadot/types';
-import { BlockNumber, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -24,9 +24,7 @@ const l = logger('Task: Motions');
  */
 const createMotion: Task<NomidotMotion[]> = {
   name: 'createMotion',
-  read: async (blockHash: Hash, api: ApiPromise): Promise<NomidotMotion[]> => {
-    const events = await api.query.system.events.at(blockHash);
-    
+  read: async (blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<NomidotMotion[]> => {
     const motionEvents = filterEvents(events, 'council', motionStatus.PROPOSED)
 
     const results: NomidotMotion[] = [];

--- a/back/node_watcher/src/tasks/createMotion.ts
+++ b/back/node_watcher/src/tasks/createMotion.ts
@@ -4,18 +4,14 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { GenericCall } from '@polkadot/types';
-import {
-  BlockNumber,
-  EventRecord,
-  Hash,
-  SessionIndex,
-} from '@polkadot/types/interfaces';
+import { BlockNumber, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
 import { filterEvents } from '../util/filterEvents';
 import { motionStatus, preimageStatus } from '../util/statuses';
 import {
+  Cached,
   NomidotArgument,
   NomidotMotion,
   NomidotMotionRawEvent,
@@ -31,10 +27,11 @@ const createMotion: Task<NomidotMotion[]> = {
   name: 'createMotion',
   read: async (
     blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
+    cached: Cached,
     api: ApiPromise
   ): Promise<NomidotMotion[]> => {
+    const { events } = cached;
+
     const motionEvents = filterEvents(events, 'council', motionStatus.PROPOSED);
 
     const results: NomidotMotion[] = [];

--- a/back/node_watcher/src/tasks/createMotion.ts
+++ b/back/node_watcher/src/tasks/createMotion.ts
@@ -4,7 +4,12 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { GenericCall } from '@polkadot/types';
-import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
+import {
+  BlockNumber,
+  EventRecord,
+  Hash,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -24,8 +29,13 @@ const l = logger('Task: Motions');
  */
 const createMotion: Task<NomidotMotion[]> = {
   name: 'createMotion',
-  read: async (blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<NomidotMotion[]> => {
-    const motionEvents = filterEvents(events, 'council', motionStatus.PROPOSED)
+  read: async (
+    blockHash: Hash,
+    events: EventRecord[],
+    sessionIndex: SessionIndex,
+    api: ApiPromise
+  ): Promise<NomidotMotion[]> => {
+    const motionEvents = filterEvents(events, 'council', motionStatus.PROPOSED);
 
     const results: NomidotMotion[] = [];
 

--- a/back/node_watcher/src/tasks/createMotionStatus.ts
+++ b/back/node_watcher/src/tasks/createMotionStatus.ts
@@ -3,10 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import {
-  BlockNumber,
-  Hash
-} from '@polkadot/types/interfaces';
+import { BlockNumber, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';

--- a/back/node_watcher/src/tasks/createMotionStatus.ts
+++ b/back/node_watcher/src/tasks/createMotionStatus.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -24,6 +24,7 @@ const createMotion: Task<NomidotMotionStatusUpdate[]> = {
   read: async (
     blockHash: Hash,
     events: EventRecord[],
+    sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotMotionStatusUpdate[]> => {
     // Proposed is handled by createMotion task

--- a/back/node_watcher/src/tasks/createMotionStatus.ts
+++ b/back/node_watcher/src/tasks/createMotionStatus.ts
@@ -3,7 +3,12 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
+import {
+  BlockNumber,
+  EventRecord,
+  Hash,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';

--- a/back/node_watcher/src/tasks/createMotionStatus.ts
+++ b/back/node_watcher/src/tasks/createMotionStatus.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -23,10 +23,9 @@ const createMotion: Task<NomidotMotionStatusUpdate[]> = {
   name: 'createMotionStatusUpdate',
   read: async (
     blockHash: Hash,
+    events: EventRecord[],
     api: ApiPromise
   ): Promise<NomidotMotionStatusUpdate[]> => {
-    const events = await api.query.system.events.at(blockHash);
-
     // Proposed is handled by createMotion task
     // Voted should be handled by a vote tracking tasks
     const motionEvents = events.filter(

--- a/back/node_watcher/src/tasks/createMotionStatus.ts
+++ b/back/node_watcher/src/tasks/createMotionStatus.ts
@@ -27,10 +27,10 @@ const l = logger('Task: Motions Status Update');
 const createMotion: Task<NomidotMotionStatusUpdate[]> = {
   name: 'createMotionStatusUpdate',
   read: async (
-    blockHash: Hash,
+    _blockHash: Hash,
     events: EventRecord[],
-    sessionIndex: SessionIndex,
-    api: ApiPromise
+    _sessionIndex: SessionIndex,
+    _api: ApiPromise
   ): Promise<NomidotMotionStatusUpdate[]> => {
     // Proposed is handled by createMotion task
     // Voted should be handled by a vote tracking tasks

--- a/back/node_watcher/src/tasks/createMotionStatus.ts
+++ b/back/node_watcher/src/tasks/createMotionStatus.ts
@@ -5,15 +5,14 @@
 import { ApiPromise } from '@polkadot/api';
 import {
   BlockNumber,
-  EventRecord,
-  Hash,
-  SessionIndex,
+  Hash
 } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
 import { motionStatus } from '../util/statuses';
 import {
+  Cached,
   NomidotMotionRawEvent,
   NomidotMotionStatusUpdate,
   Task,
@@ -28,10 +27,10 @@ const createMotion: Task<NomidotMotionStatusUpdate[]> = {
   name: 'createMotionStatusUpdate',
   read: async (
     _blockHash: Hash,
-    events: EventRecord[],
-    _sessionIndex: SessionIndex,
+    cached: Cached,
     _api: ApiPromise
   ): Promise<NomidotMotionStatusUpdate[]> => {
+    const { events } = cached;
     // Proposed is handled by createMotion task
     // Voted should be handled by a vote tracking tasks
     const motionEvents = events.filter(

--- a/back/node_watcher/src/tasks/createNominationAndValidators.ts
+++ b/back/node_watcher/src/tasks/createNominationAndValidators.ts
@@ -7,10 +7,8 @@ import { Option } from '@polkadot/types';
 import {
   AccountId,
   BlockNumber,
-  EventRecord,
   Exposure,
   Hash,
-  SessionIndex,
   StakingLedger,
   ValidatorId,
   ValidatorPrefs,
@@ -19,7 +17,7 @@ import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
 import { filterEvents } from '../util/filterEvents';
-import { NomidotNominationAndValidators, Task } from './types';
+import { Cached, NomidotNominationAndValidators, Task } from './types';
 
 const l = logger('Task: Nomination + Validators');
 
@@ -32,11 +30,11 @@ const createNominationAndValidators: Task<Set<
   name: 'createNominationAndValidators',
   read: async (
     blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
+    cached: Cached,
     api: ApiPromise
   ): Promise<Set<NomidotNominationAndValidators>> => {
     const result: Set<NomidotNominationAndValidators> = new Set();
+    const { events, sessionIndex } = cached;
 
     const didNewSessionStart =
       filterEvents(events, 'session', 'NewSession').length > 0;

--- a/back/node_watcher/src/tasks/createNominationAndValidators.ts
+++ b/back/node_watcher/src/tasks/createNominationAndValidators.ts
@@ -10,6 +10,7 @@ import {
   Exposure,
   EventRecord,
   Hash,
+  SessionIndex,
   StakingLedger,
   ValidatorId,
   ValidatorPrefs,
@@ -32,10 +33,9 @@ const createNominationAndValidators: Task<Set<
   read: async (
     blockHash: Hash,
     events: EventRecord[],
+    sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<Set<NomidotNominationAndValidators>> => {
-    const session = await api.query.session.currentIndex.at(blockHash);
-
     const result: Set<NomidotNominationAndValidators> = new Set();
 
     const didNewSessionStart =
@@ -62,7 +62,7 @@ const createNominationAndValidators: Task<Set<
           if (bonded.isNone && ledger.isNone) {
             const result = {
               stakedAmount: null,
-              session,
+              session: sessionIndex,
               nominatorController: null,
               nominatorStash: null,
               validatorPreferences: null,
@@ -119,7 +119,7 @@ const createNominationAndValidators: Task<Set<
               result.add({
                 nominatorStash,
                 nominatorController,
-                session,
+                session: sessionIndex,
                 stakedAmount: value,
                 validatorController,
                 validatorStash,

--- a/back/node_watcher/src/tasks/createNominationAndValidators.ts
+++ b/back/node_watcher/src/tasks/createNominationAndValidators.ts
@@ -8,6 +8,7 @@ import {
   AccountId,
   BlockNumber,
   Exposure,
+  EventRecord,
   Hash,
   StakingLedger,
   ValidatorId,
@@ -30,9 +31,9 @@ const createNominationAndValidators: Task<Set<
   name: 'createNominationAndValidators',
   read: async (
     blockHash: Hash,
+    events: EventRecord[],
     api: ApiPromise
   ): Promise<Set<NomidotNominationAndValidators>> => {
-    const events = await api.query.system.events.at(blockHash);
     const session = await api.query.session.currentIndex.at(blockHash);
 
     const result: Set<NomidotNominationAndValidators> = new Set();

--- a/back/node_watcher/src/tasks/createNominationAndValidators.ts
+++ b/back/node_watcher/src/tasks/createNominationAndValidators.ts
@@ -7,8 +7,8 @@ import { Option } from '@polkadot/types';
 import {
   AccountId,
   BlockNumber,
-  Exposure,
   EventRecord,
+  Exposure,
   Hash,
   SessionIndex,
   StakingLedger,

--- a/back/node_watcher/src/tasks/createOfflineValidator.ts
+++ b/back/node_watcher/src/tasks/createOfflineValidator.ts
@@ -9,6 +9,7 @@ import {
   FullIdentification,
   Hash,
   IdentificationTuple,
+  SessionIndex,
   ValidatorId,
 } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
@@ -27,6 +28,7 @@ const createOfflineValidator: Task<NomidotOfflineValidator[]> = {
   read: async (
     blockHash: Hash,
     events: EventRecord[],
+    sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotOfflineValidator[]> => {
     // At the end of the session, these validators were found to be offline.
@@ -39,8 +41,6 @@ const createOfflineValidator: Task<NomidotOfflineValidator[]> = {
     const result: NomidotOfflineValidator[] = [];
 
     if (someOfflineEvents && someOfflineEvents.length) {
-      const sessionIndex = await api.query.session.currentIndex.at(blockHash);
-
       someOfflineEvents.map(({ event: { data } }: EventRecord) => {
         data.map(idTuples => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-ignore

--- a/back/node_watcher/src/tasks/createOfflineValidator.ts
+++ b/back/node_watcher/src/tasks/createOfflineValidator.ts
@@ -25,12 +25,12 @@ const l = logger('Task: OfflineValidator');
  */
 const createOfflineValidator: Task<NomidotOfflineValidator[]> = {
   name: 'createOfflineValidator',
-  read: async (
+  read: (
     blockHash: Hash,
     events: EventRecord[],
     sessionIndex: SessionIndex,
     api: ApiPromise
-  ): Promise<NomidotOfflineValidator[]> => {
+  ): NomidotOfflineValidator[] => {
     // At the end of the session, these validators were found to be offline.
     const someOfflineEvents: EventRecord[] = filterEvents(
       events,

--- a/back/node_watcher/src/tasks/createOfflineValidator.ts
+++ b/back/node_watcher/src/tasks/createOfflineValidator.ts
@@ -26,10 +26,10 @@ const l = logger('Task: OfflineValidator');
 const createOfflineValidator: Task<NomidotOfflineValidator[]> = {
   name: 'createOfflineValidator',
   read: (
-    blockHash: Hash,
+    _blockHash: Hash,
     events: EventRecord[],
     sessionIndex: SessionIndex,
-    api: ApiPromise
+    _api: ApiPromise
   ): NomidotOfflineValidator[] => {
     // At the end of the session, these validators were found to be offline.
     const someOfflineEvents: EventRecord[] = filterEvents(

--- a/back/node_watcher/src/tasks/createOfflineValidator.ts
+++ b/back/node_watcher/src/tasks/createOfflineValidator.ts
@@ -9,14 +9,13 @@ import {
   FullIdentification,
   Hash,
   IdentificationTuple,
-  SessionIndex,
   ValidatorId,
 } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
 import { filterEvents } from '../util/filterEvents';
-import { NomidotOfflineValidator, Task } from './types';
+import { Cached, NomidotOfflineValidator, Task } from './types';
 
 const l = logger('Task: OfflineValidator');
 
@@ -27,10 +26,10 @@ const createOfflineValidator: Task<NomidotOfflineValidator[]> = {
   name: 'createOfflineValidator',
   read: (
     _blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
+    cached: Cached,
     _api: ApiPromise
   ): NomidotOfflineValidator[] => {
+    const { events, sessionIndex } = cached;
     // At the end of the session, these validators were found to be offline.
     const someOfflineEvents: EventRecord[] = filterEvents(
       events,

--- a/back/node_watcher/src/tasks/createOfflineValidator.ts
+++ b/back/node_watcher/src/tasks/createOfflineValidator.ts
@@ -26,10 +26,9 @@ const createOfflineValidator: Task<NomidotOfflineValidator[]> = {
   name: 'createOfflineValidator',
   read: async (
     blockHash: Hash,
+    events: EventRecord[],
     api: ApiPromise
   ): Promise<NomidotOfflineValidator[]> => {
-    const events = await api.query.system.events.at(blockHash);
-
     // At the end of the session, these validators were found to be offline.
     const someOfflineEvents: EventRecord[] = filterEvents(
       events,

--- a/back/node_watcher/src/tasks/createOfflineValidator.ts
+++ b/back/node_watcher/src/tasks/createOfflineValidator.ts
@@ -28,7 +28,7 @@ const createOfflineValidator: Task<NomidotOfflineValidator[]> = {
     _blockHash: Hash,
     cached: Cached,
     _api: ApiPromise
-  ): NomidotOfflineValidator[] => {
+  ): Promise<NomidotOfflineValidator[]> => {
     const { events, sessionIndex } = cached;
     // At the end of the session, these validators were found to be offline.
     const someOfflineEvents: EventRecord[] = filterEvents(
@@ -63,7 +63,7 @@ const createOfflineValidator: Task<NomidotOfflineValidator[]> = {
 
     l.log(`Offline Validators : ${JSON.stringify(result)}`);
 
-    return result;
+    return Promise.resolve(result);
   },
   write: async (
     blockNumber: BlockNumber,

--- a/back/node_watcher/src/tasks/createPreimage.ts
+++ b/back/node_watcher/src/tasks/createPreimage.ts
@@ -4,7 +4,12 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { GenericCall } from '@polkadot/types';
-import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
+import {
+  BlockNumber,
+  EventRecord,
+  Hash,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -30,7 +35,11 @@ const createPreimage: Task<NomidotPreimage[]> = {
     sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotPreimage[]> => {
-    const preimageEvents = filterEvents(events, 'democracy', preimageStatus.NOTED)
+    const preimageEvents = filterEvents(
+      events,
+      'democracy',
+      preimageStatus.NOTED
+    );
 
     const results: NomidotPreimage[] = [];
     await Promise.all(

--- a/back/node_watcher/src/tasks/createPreimage.ts
+++ b/back/node_watcher/src/tasks/createPreimage.ts
@@ -8,6 +8,7 @@ import { BlockNumber, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
+import { filterEvents } from '../util/filterEvents';
 import { preimageStatus } from '../util/statuses';
 import {
   NomidotPreimage,
@@ -28,10 +29,7 @@ const createPreimage: Task<NomidotPreimage[]> = {
     api: ApiPromise
   ): Promise<NomidotPreimage[]> => {
     const events = await api.query.system.events.at(blockHash);
-    const preimageEvents = events.filter(
-      ({ event: { method, section } }) =>
-        section === 'democracy' && method === preimageStatus.NOTED
-    );
+    const preimageEvents = filterEvents(events, 'democracy', preimageStatus.NOTED)
 
     const results: NomidotPreimage[] = [];
     await Promise.all(

--- a/back/node_watcher/src/tasks/createPreimage.ts
+++ b/back/node_watcher/src/tasks/createPreimage.ts
@@ -4,7 +4,7 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { GenericCall } from '@polkadot/types';
-import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -27,6 +27,7 @@ const createPreimage: Task<NomidotPreimage[]> = {
   read: async (
     blockHash: Hash,
     events: EventRecord[],
+    sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotPreimage[]> => {
     const preimageEvents = filterEvents(events, 'democracy', preimageStatus.NOTED)

--- a/back/node_watcher/src/tasks/createPreimage.ts
+++ b/back/node_watcher/src/tasks/createPreimage.ts
@@ -4,7 +4,7 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { GenericCall } from '@polkadot/types';
-import { BlockNumber, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -26,9 +26,9 @@ const createPreimage: Task<NomidotPreimage[]> = {
   name: 'createPreimage',
   read: async (
     blockHash: Hash,
+    events: EventRecord[],
     api: ApiPromise
   ): Promise<NomidotPreimage[]> => {
-    const events = await api.query.system.events.at(blockHash);
     const preimageEvents = filterEvents(events, 'democracy', preimageStatus.NOTED)
 
     const results: NomidotPreimage[] = [];

--- a/back/node_watcher/src/tasks/createPreimage.ts
+++ b/back/node_watcher/src/tasks/createPreimage.ts
@@ -4,18 +4,14 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { GenericCall } from '@polkadot/types';
-import {
-  BlockNumber,
-  EventRecord,
-  Hash,
-  SessionIndex,
-} from '@polkadot/types/interfaces';
+import { BlockNumber, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
 import { filterEvents } from '../util/filterEvents';
 import { preimageStatus } from '../util/statuses';
 import {
+  Cached,
   NomidotPreimage,
   NomidotPreimageEvent,
   NomidotPreimageRawEvent,
@@ -31,10 +27,11 @@ const createPreimage: Task<NomidotPreimage[]> = {
   name: 'createPreimage',
   read: async (
     blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
+    cached: Cached,
     api: ApiPromise
   ): Promise<NomidotPreimage[]> => {
+    const { events } = cached;
+
     const preimageEvents = filterEvents(
       events,
       'democracy',

--- a/back/node_watcher/src/tasks/createProposal.ts
+++ b/back/node_watcher/src/tasks/createProposal.ts
@@ -6,6 +6,7 @@ import { ApiPromise } from '@polkadot/api';
 import {
   AccountId,
   BlockNumber,
+  EventRecord,
   Hash,
   PropIndex,
 } from '@polkadot/types/interfaces';
@@ -30,10 +31,9 @@ const createProposal: Task<NomidotProposal[]> = {
   name: 'createProposal',
   read: async (
     blockHash: Hash,
+    events: EventRecord[],
     api: ApiPromise
   ): Promise<NomidotProposal[]> => {
-    const events = await api.query.system.events.at(blockHash);
-
     const proposalEvents = filterEvents(events, 'democracy', proposalStatus.PROPOSED)
 
     const results: NomidotProposal[] = [];

--- a/back/node_watcher/src/tasks/createProposal.ts
+++ b/back/node_watcher/src/tasks/createProposal.ts
@@ -9,6 +9,7 @@ import {
   EventRecord,
   Hash,
   PropIndex,
+  SessionIndex
 } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
@@ -32,6 +33,7 @@ const createProposal: Task<NomidotProposal[]> = {
   read: async (
     blockHash: Hash,
     events: EventRecord[],
+    sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotProposal[]> => {
     const proposalEvents = filterEvents(events, 'democracy', proposalStatus.PROPOSED)

--- a/back/node_watcher/src/tasks/createProposal.ts
+++ b/back/node_watcher/src/tasks/createProposal.ts
@@ -9,7 +9,7 @@ import {
   EventRecord,
   Hash,
   PropIndex,
-  SessionIndex
+  SessionIndex,
 } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
@@ -36,7 +36,11 @@ const createProposal: Task<NomidotProposal[]> = {
     sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotProposal[]> => {
-    const proposalEvents = filterEvents(events, 'democracy', proposalStatus.PROPOSED)
+    const proposalEvents = filterEvents(
+      events,
+      'democracy',
+      proposalStatus.PROPOSED
+    );
 
     const results: NomidotProposal[] = [];
 

--- a/back/node_watcher/src/tasks/createProposal.ts
+++ b/back/node_watcher/src/tasks/createProposal.ts
@@ -12,6 +12,7 @@ import {
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
+import { filterEvents } from '../util/filterEvents';
 import { preimageStatus, proposalStatus } from '../util/statuses';
 import {
   NomidotProposal,
@@ -33,10 +34,7 @@ const createProposal: Task<NomidotProposal[]> = {
   ): Promise<NomidotProposal[]> => {
     const events = await api.query.system.events.at(blockHash);
 
-    const proposalEvents = events.filter(
-      ({ event: { method, section } }) =>
-        section === 'democracy' && method === proposalStatus.PROPOSED
-    );
+    const proposalEvents = filterEvents(events, 'democracy', proposalStatus.PROPOSED)
 
     const results: NomidotProposal[] = [];
 

--- a/back/node_watcher/src/tasks/createProposal.ts
+++ b/back/node_watcher/src/tasks/createProposal.ts
@@ -6,10 +6,8 @@ import { ApiPromise } from '@polkadot/api';
 import {
   AccountId,
   BlockNumber,
-  EventRecord,
   Hash,
   PropIndex,
-  SessionIndex,
 } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
@@ -17,6 +15,7 @@ import { prisma } from '../generated/prisma-client';
 import { filterEvents } from '../util/filterEvents';
 import { preimageStatus, proposalStatus } from '../util/statuses';
 import {
+  Cached,
   NomidotProposal,
   NomidotProposalEvent,
   NomidotProposalRawEvent,
@@ -32,10 +31,10 @@ const createProposal: Task<NomidotProposal[]> = {
   name: 'createProposal',
   read: async (
     blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
+    cached: Cached,
     api: ApiPromise
   ): Promise<NomidotProposal[]> => {
+    const { events } = cached;
     const proposalEvents = filterEvents(
       events,
       'democracy',

--- a/back/node_watcher/src/tasks/createProposalStatus.ts
+++ b/back/node_watcher/src/tasks/createProposalStatus.ts
@@ -3,7 +3,12 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
+import {
+  BlockNumber,
+  EventRecord,
+  Hash,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -28,7 +33,11 @@ const createProposal: Task<NomidotProposalStatusUpdate[]> = {
     sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotProposalStatusUpdate[]> => {
-    const proposalEvents = filterEvents(events, 'democracy', proposalStatus.TABLED)
+    const proposalEvents = filterEvents(
+      events,
+      'democracy',
+      proposalStatus.TABLED
+    );
 
     const results: NomidotProposalStatusUpdate[] = [];
 

--- a/back/node_watcher/src/tasks/createProposalStatus.ts
+++ b/back/node_watcher/src/tasks/createProposalStatus.ts
@@ -28,10 +28,10 @@ const l = logger('Task: Proposals Status Update');
 const createProposal: Task<NomidotProposalStatusUpdate[]> = {
   name: 'createProposalStatusUpdate',
   read: async (
-    blockHash: Hash,
+    _blockHash: Hash,
     events: EventRecord[],
-    sessionIndex: SessionIndex,
-    api: ApiPromise
+    _sessionIndex: SessionIndex,
+    _api: ApiPromise
   ): Promise<NomidotProposalStatusUpdate[]> => {
     const proposalEvents = filterEvents(
       events,

--- a/back/node_watcher/src/tasks/createProposalStatus.ts
+++ b/back/node_watcher/src/tasks/createProposalStatus.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -25,6 +25,7 @@ const createProposal: Task<NomidotProposalStatusUpdate[]> = {
   read: async (
     blockHash: Hash,
     events: EventRecord[],
+    sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotProposalStatusUpdate[]> => {
     const proposalEvents = filterEvents(events, 'democracy', proposalStatus.TABLED)

--- a/back/node_watcher/src/tasks/createProposalStatus.ts
+++ b/back/node_watcher/src/tasks/createProposalStatus.ts
@@ -3,18 +3,14 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import {
-  BlockNumber,
-  EventRecord,
-  Hash,
-  SessionIndex,
-} from '@polkadot/types/interfaces';
+import { BlockNumber, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
 import { filterEvents } from '../util/filterEvents';
 import { proposalStatus } from '../util/statuses';
 import {
+  Cached,
   NomidotProposalRawEvent,
   NomidotProposalStatusUpdate,
   Task,
@@ -29,10 +25,11 @@ const createProposal: Task<NomidotProposalStatusUpdate[]> = {
   name: 'createProposalStatusUpdate',
   read: async (
     _blockHash: Hash,
-    events: EventRecord[],
-    _sessionIndex: SessionIndex,
+    cached: Cached,
     _api: ApiPromise
   ): Promise<NomidotProposalStatusUpdate[]> => {
+    const { events } = cached;
+
     const proposalEvents = filterEvents(
       events,
       'democracy',

--- a/back/node_watcher/src/tasks/createProposalStatus.ts
+++ b/back/node_watcher/src/tasks/createProposalStatus.ts
@@ -7,6 +7,7 @@ import { BlockNumber, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
+import { filterEvents } from '../util/filterEvents';
 import { proposalStatus } from '../util/statuses';
 import {
   NomidotProposalRawEvent,
@@ -27,10 +28,7 @@ const createProposal: Task<NomidotProposalStatusUpdate[]> = {
   ): Promise<NomidotProposalStatusUpdate[]> => {
     const events = await api.query.system.events.at(blockHash);
 
-    const proposalEvents = events.filter(
-      ({ event: { method, section } }) =>
-        section === 'democracy' && method === proposalStatus.TABLED
-    );
+    const proposalEvents = filterEvents(events, 'democracy', proposalStatus.TABLED)
 
     const results: NomidotProposalStatusUpdate[] = [];
 

--- a/back/node_watcher/src/tasks/createProposalStatus.ts
+++ b/back/node_watcher/src/tasks/createProposalStatus.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -24,10 +24,9 @@ const createProposal: Task<NomidotProposalStatusUpdate[]> = {
   name: 'createProposalStatusUpdate',
   read: async (
     blockHash: Hash,
+    events: EventRecord[],
     api: ApiPromise
   ): Promise<NomidotProposalStatusUpdate[]> => {
-    const events = await api.query.system.events.at(blockHash);
-
     const proposalEvents = filterEvents(events, 'democracy', proposalStatus.TABLED)
 
     const results: NomidotProposalStatusUpdate[] = [];

--- a/back/node_watcher/src/tasks/createReferendum.ts
+++ b/back/node_watcher/src/tasks/createReferendum.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -21,6 +21,7 @@ const createReferendum: Task<NomidotReferendum[]> = {
   read: async (
     blockHash: Hash,
     events: EventRecord[],
+    sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotReferendum[]> => {
     const referendumEvents = filterEvents(events, 'democracy', referendumStatus.STARTED)

--- a/back/node_watcher/src/tasks/createReferendum.ts
+++ b/back/node_watcher/src/tasks/createReferendum.ts
@@ -7,6 +7,7 @@ import { BlockNumber, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
+import { filterEvents } from '../util/filterEvents';
 import { preimageStatus, referendumStatus } from '../util/statuses';
 import { NomidotReferendum, NomidotReferendumRawEvent, Task } from './types';
 
@@ -23,10 +24,7 @@ const createReferendum: Task<NomidotReferendum[]> = {
   ): Promise<NomidotReferendum[]> => {
     const events = await api.query.system.events.at(blockHash);
 
-    const referendumEvents = events.filter(
-      ({ event: { method, section } }) =>
-        section === 'democracy' && method === referendumStatus.STARTED
-    );
+    const referendumEvents = filterEvents(events, 'democracy', referendumStatus.STARTED)
 
     const results: NomidotReferendum[] = [];
 

--- a/back/node_watcher/src/tasks/createReferendum.ts
+++ b/back/node_watcher/src/tasks/createReferendum.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -20,10 +20,9 @@ const createReferendum: Task<NomidotReferendum[]> = {
   name: 'createReferendum',
   read: async (
     blockHash: Hash,
+    events: EventRecord[],
     api: ApiPromise
   ): Promise<NomidotReferendum[]> => {
-    const events = await api.query.system.events.at(blockHash);
-
     const referendumEvents = filterEvents(events, 'democracy', referendumStatus.STARTED)
 
     const results: NomidotReferendum[] = [];

--- a/back/node_watcher/src/tasks/createReferendum.ts
+++ b/back/node_watcher/src/tasks/createReferendum.ts
@@ -3,18 +3,18 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import {
-  BlockNumber,
-  EventRecord,
-  Hash,
-  SessionIndex,
-} from '@polkadot/types/interfaces';
+import { BlockNumber, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
 import { filterEvents } from '../util/filterEvents';
 import { preimageStatus, referendumStatus } from '../util/statuses';
-import { NomidotReferendum, NomidotReferendumRawEvent, Task } from './types';
+import {
+  Cached,
+  NomidotReferendum,
+  NomidotReferendumRawEvent,
+  Task,
+} from './types';
 
 const l = logger('Task: Referenda');
 
@@ -25,10 +25,11 @@ const createReferendum: Task<NomidotReferendum[]> = {
   name: 'createReferendum',
   read: async (
     blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
+    cached: Cached,
     api: ApiPromise
   ): Promise<NomidotReferendum[]> => {
+    const { events } = cached;
+
     const referendumEvents = filterEvents(
       events,
       'democracy',

--- a/back/node_watcher/src/tasks/createReferendum.ts
+++ b/back/node_watcher/src/tasks/createReferendum.ts
@@ -3,7 +3,12 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
+import {
+  BlockNumber,
+  EventRecord,
+  Hash,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -24,7 +29,11 @@ const createReferendum: Task<NomidotReferendum[]> = {
     sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotReferendum[]> => {
-    const referendumEvents = filterEvents(events, 'democracy', referendumStatus.STARTED)
+    const referendumEvents = filterEvents(
+      events,
+      'democracy',
+      referendumStatus.STARTED
+    );
 
     const results: NomidotReferendum[] = [];
 

--- a/back/node_watcher/src/tasks/createReferendumStatus.ts
+++ b/back/node_watcher/src/tasks/createReferendumStatus.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -24,6 +24,7 @@ const createReferendumStatus: Task<NomidotReferendumStatusUpdate[]> = {
   read: async (
     blockHash: Hash,
     events: EventRecord[],
+    sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotReferendumStatusUpdate[]> => {
 

--- a/back/node_watcher/src/tasks/createReferendumStatus.ts
+++ b/back/node_watcher/src/tasks/createReferendumStatus.ts
@@ -3,17 +3,13 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import {
-  BlockNumber,
-  EventRecord,
-  Hash,
-  SessionIndex,
-} from '@polkadot/types/interfaces';
+import { BlockNumber, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
 import { referendumStatus } from '../util/statuses';
 import {
+  Cached,
   NomidotReferendumRawEvent,
   NomidotReferendumStatusUpdate,
   Task,
@@ -28,10 +24,11 @@ const createReferendumStatus: Task<NomidotReferendumStatusUpdate[]> = {
   name: 'createReferendumStatusUpdate',
   read: async (
     _blockHash: Hash,
-    events: EventRecord[],
-    _sessionIndex: SessionIndex,
+    cached: Cached,
     _api: ApiPromise
   ): Promise<NomidotReferendumStatusUpdate[]> => {
+    const { events } = cached;
+
     // The "Started" event is taken care of by the createReferendum
     // task, so we need to filter it out.
     const referendumEvents = events.filter(

--- a/back/node_watcher/src/tasks/createReferendumStatus.ts
+++ b/back/node_watcher/src/tasks/createReferendumStatus.ts
@@ -27,10 +27,10 @@ const l = logger('Task: Referendum Status Update');
 const createReferendumStatus: Task<NomidotReferendumStatusUpdate[]> = {
   name: 'createReferendumStatusUpdate',
   read: async (
-    blockHash: Hash,
+    _blockHash: Hash,
     events: EventRecord[],
-    sessionIndex: SessionIndex,
-    api: ApiPromise
+    _sessionIndex: SessionIndex,
+    _api: ApiPromise
   ): Promise<NomidotReferendumStatusUpdate[]> => {
     // The "Started" event is taken care of by the createReferendum
     // task, so we need to filter it out.

--- a/back/node_watcher/src/tasks/createReferendumStatus.ts
+++ b/back/node_watcher/src/tasks/createReferendumStatus.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -23,9 +23,9 @@ const createReferendumStatus: Task<NomidotReferendumStatusUpdate[]> = {
   name: 'createReferendumStatusUpdate',
   read: async (
     blockHash: Hash,
+    events: EventRecord[],
     api: ApiPromise
   ): Promise<NomidotReferendumStatusUpdate[]> => {
-    const events = await api.query.system.events.at(blockHash);
 
     // The "Started" event is taken care of by the createReferendum
     // task, so we need to filter it out.

--- a/back/node_watcher/src/tasks/createReferendumStatus.ts
+++ b/back/node_watcher/src/tasks/createReferendumStatus.ts
@@ -3,7 +3,12 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
+import {
+  BlockNumber,
+  EventRecord,
+  Hash,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -27,7 +32,6 @@ const createReferendumStatus: Task<NomidotReferendumStatusUpdate[]> = {
     sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotReferendumStatusUpdate[]> => {
-
     // The "Started" event is taken care of by the createReferendum
     // task, so we need to filter it out.
     const referendumEvents = events.filter(

--- a/back/node_watcher/src/tasks/createReward.ts
+++ b/back/node_watcher/src/tasks/createReward.ts
@@ -17,9 +17,7 @@ const l = logger('Task: Reward');
  */
 const createReward: Task<NomidotReward[]> = {
   name: 'createReward',
-  read: async (blockHash: Hash, api: ApiPromise): Promise<NomidotReward[]> => {
-    const events = await api.query.system.events.at(blockHash);
-
+  read: async (blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<NomidotReward[]> => {
     const rewardEvents: EventRecord[] = filterEvents(
       events,
       'staking',

--- a/back/node_watcher/src/tasks/createReward.ts
+++ b/back/node_watcher/src/tasks/createReward.ts
@@ -6,14 +6,13 @@ import { ApiPromise } from '@polkadot/api';
 import {
   BlockNumber,
   EventRecord,
-  Hash,
-  SessionIndex,
+  Hash
 } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
 import { filterEvents } from '../util/filterEvents';
-import { NomidotReward, Task } from './types';
+import { Cached, NomidotReward, Task } from './types';
 
 const l = logger('Task: Reward');
 
@@ -22,12 +21,9 @@ const l = logger('Task: Reward');
  */
 const createReward: Task<NomidotReward[]> = {
   name: 'createReward',
-  read: (
-    blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
-    api: ApiPromise
-  ): NomidotReward[] => {
+  read: (blockHash: Hash, cached: Cached, api: ApiPromise): NomidotReward[] => {
+    const { events, sessionIndex } = cached;
+
     const rewardEvents: EventRecord[] = filterEvents(
       events,
       'staking',

--- a/back/node_watcher/src/tasks/createReward.ts
+++ b/back/node_watcher/src/tasks/createReward.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -17,7 +17,7 @@ const l = logger('Task: Reward');
  */
 const createReward: Task<NomidotReward[]> = {
   name: 'createReward',
-  read: async (blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<NomidotReward[]> => {
+  read: async (blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<NomidotReward[]> => {
     const rewardEvents: EventRecord[] = filterEvents(
       events,
       'staking',
@@ -27,8 +27,6 @@ const createReward: Task<NomidotReward[]> = {
     const result: NomidotReward[] = [];
 
     if (rewardEvents) {
-      const sessionIndex = await api.query.session.currentIndex.at(blockHash);
-
       rewardEvents.map(({ event: { data } }) => {
         const treasuryReward = api.createType('Balance', data[1]);
         const validatorReward = api.createType('Balance', data[0]);

--- a/back/node_watcher/src/tasks/createReward.ts
+++ b/back/node_watcher/src/tasks/createReward.ts
@@ -21,7 +21,7 @@ const l = logger('Task: Reward');
  */
 const createReward: Task<NomidotReward[]> = {
   name: 'createReward',
-  read: (blockHash: Hash, cached: Cached, api: ApiPromise): NomidotReward[] => {
+  read: (blockHash: Hash, cached: Cached, api: ApiPromise): Promise<NomidotReward[]> => {
     const { events, sessionIndex } = cached;
 
     const rewardEvents: EventRecord[] = filterEvents(
@@ -48,7 +48,7 @@ const createReward: Task<NomidotReward[]> = {
 
     l.log(`Reward: ${JSON.stringify(result)}`);
 
-    return result;
+    return Promise.resolve(result);
   },
   write: async (_blockNumber: BlockNumber, rewards: NomidotReward[]) => {
     await Promise.all(

--- a/back/node_watcher/src/tasks/createReward.ts
+++ b/back/node_watcher/src/tasks/createReward.ts
@@ -3,7 +3,12 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
+import {
+  BlockNumber,
+  EventRecord,
+  Hash,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -17,7 +22,12 @@ const l = logger('Task: Reward');
  */
 const createReward: Task<NomidotReward[]> = {
   name: 'createReward',
-  read: async (blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<NomidotReward[]> => {
+  read: (
+    blockHash: Hash,
+    events: EventRecord[],
+    sessionIndex: SessionIndex,
+    api: ApiPromise
+  ): NomidotReward[] => {
     const rewardEvents: EventRecord[] = filterEvents(
       events,
       'staking',

--- a/back/node_watcher/src/tasks/createReward.ts
+++ b/back/node_watcher/src/tasks/createReward.ts
@@ -3,11 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import {
-  BlockNumber,
-  EventRecord,
-  Hash
-} from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -21,7 +17,11 @@ const l = logger('Task: Reward');
  */
 const createReward: Task<NomidotReward[]> = {
   name: 'createReward',
-  read: (blockHash: Hash, cached: Cached, api: ApiPromise): Promise<NomidotReward[]> => {
+  read: (
+    blockHash: Hash,
+    cached: Cached,
+    api: ApiPromise
+  ): Promise<NomidotReward[]> => {
     const { events, sessionIndex } = cached;
 
     const rewardEvents: EventRecord[] = filterEvents(

--- a/back/node_watcher/src/tasks/createReward.ts
+++ b/back/node_watcher/src/tasks/createReward.ts
@@ -54,7 +54,7 @@ const createReward: Task<NomidotReward[]> = {
 
     return result;
   },
-  write: async (blockNumber: BlockNumber, rewards: NomidotReward[]) => {
+  write: async (_blockNumber: BlockNumber, rewards: NomidotReward[]) => {
     await Promise.all(
       rewards.map(
         async ({

--- a/back/node_watcher/src/tasks/createSession.ts
+++ b/back/node_watcher/src/tasks/createSession.ts
@@ -21,7 +21,7 @@ const createSession: Task<NomidotSession> = {
     _blockHash: Hash,
     cached: Cached,
     _api: ApiPromise
-  ): NomidotSession => {
+  ): Promise<NomidotSession> => {
     const { events, sessionIndex } = cached;
 
     const didNewSessionStart =
@@ -34,7 +34,7 @@ const createSession: Task<NomidotSession> = {
 
     l.log(`Nomidot Session: ${JSON.stringify(result)}`);
 
-    return result;
+    return Promise.resolve(result);
   },
   write: async (blockNumber: BlockNumber, value: NomidotSession) => {
     const { didNewSessionStart, idx } = value;

--- a/back/node_watcher/src/tasks/createSession.ts
+++ b/back/node_watcher/src/tasks/createSession.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -17,9 +17,7 @@ const l = logger('Task: Session');
  */
 const createSession: Task<NomidotSession> = {
   name: 'createSession',
-  read: async (blockHash: Hash, api: ApiPromise): Promise<NomidotSession> => {
-    const events = await api.query.system.events.at(blockHash);
-
+  read: async (blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<NomidotSession> => {
     const didNewSessionStart =
       filterEvents(events, 'session', 'NewSession').length > 0;
 

--- a/back/node_watcher/src/tasks/createSession.ts
+++ b/back/node_watcher/src/tasks/createSession.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -17,11 +17,9 @@ const l = logger('Task: Session');
  */
 const createSession: Task<NomidotSession> = {
   name: 'createSession',
-  read: async (blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<NomidotSession> => {
+  read: async (blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<NomidotSession> => {
     const didNewSessionStart =
       filterEvents(events, 'session', 'NewSession').length > 0;
-
-    const sessionIndex = await api.query.session.currentIndex.at(blockHash);
 
     const result = {
       didNewSessionStart,

--- a/back/node_watcher/src/tasks/createSession.ts
+++ b/back/node_watcher/src/tasks/createSession.ts
@@ -3,7 +3,12 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
+import {
+  BlockNumber,
+  EventRecord,
+  Hash,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -17,7 +22,12 @@ const l = logger('Task: Session');
  */
 const createSession: Task<NomidotSession> = {
   name: 'createSession',
-  read: async (blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<NomidotSession> => {
+  read: (
+    blockHash: Hash,
+    events: EventRecord[],
+    sessionIndex: SessionIndex,
+    api: ApiPromise
+  ): NomidotSession => {
     const didNewSessionStart =
       filterEvents(events, 'session', 'NewSession').length > 0;
 

--- a/back/node_watcher/src/tasks/createSession.ts
+++ b/back/node_watcher/src/tasks/createSession.ts
@@ -3,17 +3,12 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import {
-  BlockNumber,
-  EventRecord,
-  Hash,
-  SessionIndex,
-} from '@polkadot/types/interfaces';
+import { BlockNumber, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
 import { filterEvents } from '../util/filterEvents';
-import { NomidotSession, Task } from './types';
+import { Cached, NomidotSession, Task } from './types';
 
 const l = logger('Task: Session');
 
@@ -24,10 +19,11 @@ const createSession: Task<NomidotSession> = {
   name: 'createSession',
   read: (
     _blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
+    cached: Cached,
     _api: ApiPromise
   ): NomidotSession => {
+    const { events, sessionIndex } = cached;
+
     const didNewSessionStart =
       filterEvents(events, 'session', 'NewSession').length > 0;
 

--- a/back/node_watcher/src/tasks/createSession.ts
+++ b/back/node_watcher/src/tasks/createSession.ts
@@ -23,10 +23,10 @@ const l = logger('Task: Session');
 const createSession: Task<NomidotSession> = {
   name: 'createSession',
   read: (
-    blockHash: Hash,
+    _blockHash: Hash,
     events: EventRecord[],
     sessionIndex: SessionIndex,
-    api: ApiPromise
+    _api: ApiPromise
   ): NomidotSession => {
     const didNewSessionStart =
       filterEvents(events, 'session', 'NewSession').length > 0;

--- a/back/node_watcher/src/tasks/createSlashing.ts
+++ b/back/node_watcher/src/tasks/createSlashing.ts
@@ -7,14 +7,13 @@ import { createType } from '@polkadot/types';
 import {
   BlockNumber,
   EventRecord,
-  Hash,
-  SessionIndex,
+  Hash
 } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
 import { filterEvents } from '../util/filterEvents';
-import { NomidotSlashing, Task } from './types';
+import { Cached, NomidotSlashing, Task } from './types';
 
 const l = logger('Task: Slashing');
 
@@ -25,10 +24,10 @@ const createSlashing: Task<NomidotSlashing[]> = {
   name: 'createSlashing',
   read: (
     _blockHash: Hash,
-    events: EventRecord[],
-    _sessionIndex: SessionIndex,
+    cached: Cached,
     api: ApiPromise
   ): NomidotSlashing[] => {
+    const { events } = cached;
     const slashEvents = filterEvents(events, 'staking', 'Slash');
 
     const result: NomidotSlashing[] = [];

--- a/back/node_watcher/src/tasks/createSlashing.ts
+++ b/back/node_watcher/src/tasks/createSlashing.ts
@@ -20,13 +20,10 @@ const createSlashing: Task<NomidotSlashing[]> = {
   name: 'createSlashing',
   read: async (
     blockHash: Hash,
+    events: EventRecord[],
     api: ApiPromise
   ): Promise<NomidotSlashing[]> => {
-    const eventsAtBlock: Vec<EventRecord> = await api.query.system.events.at(
-      blockHash
-    );
-
-    const slashEvents = filterEvents(eventsAtBlock, 'staking', 'Slash');
+    const slashEvents = filterEvents(events, 'staking', 'Slash');
 
     const result: NomidotSlashing[] = [];
 

--- a/back/node_watcher/src/tasks/createSlashing.ts
+++ b/back/node_watcher/src/tasks/createSlashing.ts
@@ -4,7 +4,7 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { createType, Vec } from '@polkadot/types';
-import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -21,6 +21,7 @@ const createSlashing: Task<NomidotSlashing[]> = {
   read: async (
     blockHash: Hash,
     events: EventRecord[],
+    sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotSlashing[]> => {
     const slashEvents = filterEvents(events, 'staking', 'Slash');

--- a/back/node_watcher/src/tasks/createSlashing.ts
+++ b/back/node_watcher/src/tasks/createSlashing.ts
@@ -26,7 +26,7 @@ const createSlashing: Task<NomidotSlashing[]> = {
     _blockHash: Hash,
     cached: Cached,
     api: ApiPromise
-  ): NomidotSlashing[] => {
+  ): Promise<NomidotSlashing[]> => {
     const { events } = cached;
     const slashEvents = filterEvents(events, 'staking', 'Slash');
 
@@ -41,7 +41,7 @@ const createSlashing: Task<NomidotSlashing[]> = {
 
     l.log(`Nomidot Slashing: ${JSON.stringify(result)}`);
 
-    return result;
+    return Promise.resolve(result);
   },
   write: async (blockNumber: BlockNumber, value: NomidotSlashing[]) => {
     await Promise.all(

--- a/back/node_watcher/src/tasks/createSlashing.ts
+++ b/back/node_watcher/src/tasks/createSlashing.ts
@@ -24,9 +24,9 @@ const l = logger('Task: Slashing');
 const createSlashing: Task<NomidotSlashing[]> = {
   name: 'createSlashing',
   read: (
-    blockHash: Hash,
+    _blockHash: Hash,
     events: EventRecord[],
-    sessionIndex: SessionIndex,
+    _sessionIndex: SessionIndex,
     api: ApiPromise
   ): NomidotSlashing[] => {
     const slashEvents = filterEvents(events, 'staking', 'Slash');

--- a/back/node_watcher/src/tasks/createSlashing.ts
+++ b/back/node_watcher/src/tasks/createSlashing.ts
@@ -4,11 +4,7 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { createType } from '@polkadot/types';
-import {
-  BlockNumber,
-  EventRecord,
-  Hash
-} from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';

--- a/back/node_watcher/src/tasks/createSlashing.ts
+++ b/back/node_watcher/src/tasks/createSlashing.ts
@@ -9,6 +9,7 @@ import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
 import { NomidotSlashing, Task } from './types';
+import { filterEvents } from 'src/util/filterEvents';
 
 const l = logger('Task: Slashing');
 
@@ -25,10 +26,7 @@ const createSlashing: Task<NomidotSlashing[]> = {
       blockHash
     );
 
-    const slashEvents = eventsAtBlock.filter(
-      ({ event: { section, method } }) =>
-        section === 'staking' && method === 'Slash'
-    );
+    const slashEvents = filterEvents(eventsAtBlock, 'staking', 'Slash');
 
     const result: NomidotSlashing[] = [];
 

--- a/back/node_watcher/src/tasks/createSlashing.ts
+++ b/back/node_watcher/src/tasks/createSlashing.ts
@@ -3,13 +3,18 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { createType, Vec } from '@polkadot/types';
-import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
+import { createType } from '@polkadot/types';
+import {
+  BlockNumber,
+  EventRecord,
+  Hash,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
+import { filterEvents } from '../util/filterEvents';
 import { NomidotSlashing, Task } from './types';
-import { filterEvents } from 'src/util/filterEvents';
 
 const l = logger('Task: Slashing');
 
@@ -18,17 +23,17 @@ const l = logger('Task: Slashing');
  */
 const createSlashing: Task<NomidotSlashing[]> = {
   name: 'createSlashing',
-  read: async (
+  read: (
     blockHash: Hash,
     events: EventRecord[],
     sessionIndex: SessionIndex,
     api: ApiPromise
-  ): Promise<NomidotSlashing[]> => {
+  ): NomidotSlashing[] => {
     const slashEvents = filterEvents(events, 'staking', 'Slash');
 
     const result: NomidotSlashing[] = [];
 
-    slashEvents.map(({ event: { data } }) => {
+    slashEvents.map(({ event: { data } }: EventRecord) => {
       result.push({
         who: createType(api.registry, 'AccountId', data[0].toString()),
         amount: createType(api.registry, 'Balance', data[1].toString()),

--- a/back/node_watcher/src/tasks/createStake.ts
+++ b/back/node_watcher/src/tasks/createStake.ts
@@ -4,7 +4,13 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { createType } from '@polkadot/types';
-import { BlockNumber, EventRecord, Exposure, Hash, SessionIndex } from '@polkadot/types/interfaces';
+import {
+  BlockNumber,
+  EventRecord,
+  Exposure,
+  Hash,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 import BN from 'bn.js';
 
@@ -18,7 +24,12 @@ const l = logger('Task: Stake');
  */
 const createStake: Task<NomidotStake> = {
   name: 'createStake',
-  read: async (blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<NomidotStake> => {
+  read: async (
+    blockHash: Hash,
+    events: EventRecord[],
+    sessionIndex: SessionIndex,
+    api: ApiPromise
+  ): Promise<NomidotStake> => {
     const currentElected = await api.query.staking.currentElected.at(blockHash);
     const stakersInfoForEachCurrentElectedValidator: Exposure[] = [];
     let totalStaked = new BN(0);

--- a/back/node_watcher/src/tasks/createStake.ts
+++ b/back/node_watcher/src/tasks/createStake.ts
@@ -4,7 +4,7 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { createType } from '@polkadot/types';
-import { BlockNumber, Exposure, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Exposure, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 import BN from 'bn.js';
 
@@ -18,7 +18,7 @@ const l = logger('Task: Stake');
  */
 const createStake: Task<NomidotStake> = {
   name: 'createStake',
-  read: async (blockHash: Hash, api: ApiPromise): Promise<NomidotStake> => {
+  read: async (blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<NomidotStake> => {
     const currentElected = await api.query.staking.currentElected.at(blockHash);
     const stakersInfoForEachCurrentElectedValidator: Exposure[] = [];
     let totalStaked = new BN(0);

--- a/back/node_watcher/src/tasks/createStake.ts
+++ b/back/node_watcher/src/tasks/createStake.ts
@@ -4,7 +4,7 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { createType } from '@polkadot/types';
-import { BlockNumber, EventRecord, Exposure, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Exposure, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 import BN from 'bn.js';
 
@@ -18,7 +18,7 @@ const l = logger('Task: Stake');
  */
 const createStake: Task<NomidotStake> = {
   name: 'createStake',
-  read: async (blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<NomidotStake> => {
+  read: async (blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<NomidotStake> => {
     const currentElected = await api.query.staking.currentElected.at(blockHash);
     const stakersInfoForEachCurrentElectedValidator: Exposure[] = [];
     let totalStaked = new BN(0);

--- a/back/node_watcher/src/tasks/createStake.ts
+++ b/back/node_watcher/src/tasks/createStake.ts
@@ -4,18 +4,12 @@
 
 import { ApiPromise } from '@polkadot/api';
 import { createType } from '@polkadot/types';
-import {
-  BlockNumber,
-  EventRecord,
-  Exposure,
-  Hash,
-  SessionIndex,
-} from '@polkadot/types/interfaces';
+import { BlockNumber, Exposure, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 import BN from 'bn.js';
 
 import { prisma } from '../generated/prisma-client';
-import { NomidotStake, Task } from './types';
+import { Cached, NomidotStake, Task } from './types';
 
 const l = logger('Task: Stake');
 
@@ -26,8 +20,7 @@ const createStake: Task<NomidotStake> = {
   name: 'createStake',
   read: async (
     blockHash: Hash,
-    _events: EventRecord[],
-    _sessionIndex: SessionIndex,
+    _cached: Cached,
     api: ApiPromise
   ): Promise<NomidotStake> => {
     const currentElected = await api.query.staking.currentElected.at(blockHash);

--- a/back/node_watcher/src/tasks/createStake.ts
+++ b/back/node_watcher/src/tasks/createStake.ts
@@ -26,8 +26,8 @@ const createStake: Task<NomidotStake> = {
   name: 'createStake',
   read: async (
     blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
+    _events: EventRecord[],
+    _sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotStake> => {
     const currentElected = await api.query.staking.currentElected.at(blockHash);

--- a/back/node_watcher/src/tasks/createTotalIssuance.ts
+++ b/back/node_watcher/src/tasks/createTotalIssuance.ts
@@ -3,16 +3,11 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import {
-  BlockNumber,
-  EventRecord,
-  Hash,
-  SessionIndex,
-} from '@polkadot/types/interfaces';
+import { BlockNumber, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
-import { NomidotTotalIssuance, Task } from './types';
+import { Cached, NomidotTotalIssuance, Task } from './types';
 
 const l = logger('Task: TotalIssuance');
 
@@ -23,8 +18,7 @@ const createTotalIssuance: Task<NomidotTotalIssuance> = {
   name: 'createTotalIssuance',
   read: async (
     blockHash: Hash,
-    _events: EventRecord[],
-    _sessionIndex: SessionIndex,
+    _cached: Cached,
     api: ApiPromise
   ): Promise<NomidotTotalIssuance> => {
     const amount = await api.query.balances.totalIssuance.at(blockHash);

--- a/back/node_watcher/src/tasks/createTotalIssuance.ts
+++ b/back/node_watcher/src/tasks/createTotalIssuance.ts
@@ -3,7 +3,12 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
+import {
+  BlockNumber,
+  EventRecord,
+  Hash,
+  SessionIndex,
+} from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';

--- a/back/node_watcher/src/tasks/createTotalIssuance.ts
+++ b/back/node_watcher/src/tasks/createTotalIssuance.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -19,6 +19,7 @@ const createTotalIssuance: Task<NomidotTotalIssuance> = {
   read: async (
     blockHash: Hash,
     events: EventRecord[],
+    sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotTotalIssuance> => {
     const amount = await api.query.balances.totalIssuance.at(blockHash);

--- a/back/node_watcher/src/tasks/createTotalIssuance.ts
+++ b/back/node_watcher/src/tasks/createTotalIssuance.ts
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { ApiPromise } from '@polkadot/api';
-import { BlockNumber, Hash } from '@polkadot/types/interfaces';
+import { BlockNumber, EventRecord, Hash } from '@polkadot/types/interfaces';
 import { logger } from '@polkadot/util';
 
 import { prisma } from '../generated/prisma-client';
@@ -18,6 +18,7 @@ const createTotalIssuance: Task<NomidotTotalIssuance> = {
   name: 'createTotalIssuance',
   read: async (
     blockHash: Hash,
+    events: EventRecord[],
     api: ApiPromise
   ): Promise<NomidotTotalIssuance> => {
     const amount = await api.query.balances.totalIssuance.at(blockHash);

--- a/back/node_watcher/src/tasks/createTotalIssuance.ts
+++ b/back/node_watcher/src/tasks/createTotalIssuance.ts
@@ -23,8 +23,8 @@ const createTotalIssuance: Task<NomidotTotalIssuance> = {
   name: 'createTotalIssuance',
   read: async (
     blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
+    _events: EventRecord[],
+    _sessionIndex: SessionIndex,
     api: ApiPromise
   ): Promise<NomidotTotalIssuance> => {
     const amount = await api.query.balances.totalIssuance.at(blockHash);

--- a/back/node_watcher/src/tasks/types.ts
+++ b/back/node_watcher/src/tasks/types.ts
@@ -30,7 +30,12 @@ import {
 
 export interface Task<T> {
   name: string;
-  read(blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<T>;
+  read(
+    blockHash: Hash,
+    events: EventRecord[],
+    sessionIndex: SessionIndex,
+    api: ApiPromise
+  ): T | Promise<T>;
   write(blockNumber: BlockNumber, value: T): Promise<void>;
 }
 

--- a/back/node_watcher/src/tasks/types.ts
+++ b/back/node_watcher/src/tasks/types.ts
@@ -30,7 +30,7 @@ import {
 
 export interface Task<T> {
   name: string;
-  read(blockHash: Hash, cached: Cached, api: ApiPromise): T | Promise<T>;
+  read(blockHash: Hash, cached: Cached, api: ApiPromise): Promise<T>;
   write(blockNumber: BlockNumber, value: T): Promise<void>;
 }
 

--- a/back/node_watcher/src/tasks/types.ts
+++ b/back/node_watcher/src/tasks/types.ts
@@ -30,13 +30,13 @@ import {
 
 export interface Task<T> {
   name: string;
-  read(
-    blockHash: Hash,
-    events: EventRecord[],
-    sessionIndex: SessionIndex,
-    api: ApiPromise
-  ): T | Promise<T>;
+  read(blockHash: Hash, cached: Cached, api: ApiPromise): T | Promise<T>;
   write(blockNumber: BlockNumber, value: T): Promise<void>;
+}
+
+export interface Cached {
+  events: EventRecord[];
+  sessionIndex: SessionIndex;
 }
 
 export interface NomidotBlock {

--- a/back/node_watcher/src/tasks/types.ts
+++ b/back/node_watcher/src/tasks/types.ts
@@ -30,7 +30,7 @@ import {
 
 export interface Task<T> {
   name: string;
-  read(blockHash: Hash, api: ApiPromise): Promise<T>;
+  read(blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<T>;
   write(blockNumber: BlockNumber, value: T): Promise<void>;
 }
 

--- a/back/node_watcher/src/tasks/types.ts
+++ b/back/node_watcher/src/tasks/types.ts
@@ -30,7 +30,7 @@ import {
 
 export interface Task<T> {
   name: string;
-  read(blockHash: Hash, events: EventRecord[], api: ApiPromise): Promise<T>;
+  read(blockHash: Hash, events: EventRecord[], sessionIndex: SessionIndex, api: ApiPromise): Promise<T>;
   write(blockNumber: BlockNumber, value: T): Promise<void>;
 }
 


### PR DESCRIPTION
#160 
- [x] : use filterEvents util function
- [x] : pull out event queries to once per block
- [x] : pull out session index queries to once per block
- [x] : make sure things that happen once per session only get queried when an entry doesn't already exist for that session
  - heartbeats: this comes from events so to query chaindb to check existence would actually be counterprodcutive.
  - nominators: done
  - validators: done