### PR TITLE
Add index to last 50k job

### DIFF
--- a/back/node_watcher/kubernetes/nomidotwatcher-last-50k-job.yaml
+++ b/back/node_watcher/kubernetes/nomidotwatcher-last-50k-job.yaml
@@ -27,7 +27,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: nomidotwatcher
-          image: eu.gcr.io/test-installations-222013/nomidot_watcher@sha256:d3496521d5ffd1eab2bdcca0bd5a5b1a4644dc3fbbca6b4a34ffa9c95717832b
+          image: eu.gcr.io/test-installations-222013/nomidot_watcher@sha256:12a1ab7eb7138068b6a562cd0d386f64d50b55bd883643e00d1e569b1e08985c
           imagePullPolicy: Always
           env:
             - name: PRISMA_ENDPOINT

--- a/back/node_watcher/kubernetes/nomidotwatcher-last-50k-job.yaml
+++ b/back/node_watcher/kubernetes/nomidotwatcher-last-50k-job.yaml
@@ -33,5 +33,7 @@ spec:
             - name: PRISMA_ENDPOINT
               value: http://10.0.9.43:4466
             - name: START_FROM
-              value: '1135256'
+              value: '1177733'
+            - name: BLOCK_IDENTIFIER
+              value: 'last-50k'
           command: ["yarn", "start"]


### PR DESCRIPTION
Just relaunched last 50K job that stopped at block 1177733
(Origin of the stop is logged here: https://github.com/paritytech/Nomidot/issues/218)

This PR adds a dedicated index to allow us to "simply" relaunch the job, whenever it fails.