### PR TITLE
added ingress controller with basic-auth

### DIFF
--- a/front/kubernetes/staging/ingress.yaml
+++ b/front/kubernetes/staging/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+  auth: YTokYXByMSRWdVhZTHVFSiRVMHZhZHJjUUw3YmJsZjdFRG1DUUIx
+kind: Secret
+metadata:
+  name: nodewatcher-basic-auth
+type: Opaque
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: nodewatcher-ingress
+  labels:
+    app: nodewatcher
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.frontend.entryPoints: "https,http"
+    ingress.kubernetes.io/auth-type: basic
+    ingress.kubernetes.io/auth-secret: nodewatcher-basic-auth
+spec:
+  rules:
+  - host: nodewatcher-staging.polkassembly.io
+    http:
+      paths:
+      - backend:
+          serviceName: nodewatcher
+          servicePort: 4466
+        path: /


### PR DESCRIPTION
Added an ingress controller to the k8s staging deployment. Mostly to give the *polkassembly* project access to the nodewatcher. It implements ssl and a http basic-auth. 
