### PR TITLE
feat: v1.5 sync

### DIFF
--- a/back/node_watcher/kubernetes/v1.5/nodewatcher-deployment-staging.yaml
+++ b/back/node_watcher/kubernetes/v1.5/nodewatcher-deployment-staging.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nodewatcher
+  name: nodewatcher-v1.5
   namespace: nodewatcher-staging
   labels:
     stage: staging
-    name: nodewatcher
-    app: nodewatcher
+    name:  nodewatcher-v1.5
+    app:  nodewatcher-v1.5
 spec:
   selector:
     matchLabels:
-      app: nodewatcher
+      app:  nodewatcher-v1.5
   replicas: 1
   strategy:
     type: RollingUpdate
@@ -18,8 +18,8 @@ spec:
     metadata:
       labels:
         stage: staging
-        name: nodewatcher
-        app: nodewatcher
+        name:  nodewatcher-v1.5
+        app:  nodewatcher-v1.5
     spec:
       containers:
         - name: prisma
@@ -36,17 +36,17 @@ spec:
             - name: DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: cloudsql-db-credentials
+                  name: cloudsql-db-credentials-v1.5
                   key: username
             - name: DB_PASS
               valueFrom:
                 secretKeyRef:
-                  name: cloudsql-db-credentials
+                  name: cloudsql-db-credentials-v1.5
                   key: password
             - name: DB_NAME
               valueFrom:
                 secretKeyRef:
-                  name: cloudsql-db-credentials
+                  name: cloudsql-db-credentials-v1.5
                   key: dbname
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:1.16

--- a/back/node_watcher/kubernetes/v1.5/nodewatcher-service.yaml
+++ b/back/node_watcher/kubernetes/v1.5/nodewatcher-service.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nodewatcher
+  name: nodewatcher-v1-5
   namespace: nodewatcher-staging
   labels:
     stage: staging
-    name: nodewatcher
-    app: nodewatcher
+    name: nodewatcher-v1.5
+    app: nodewatcher-v1.5
 spec:
   type: ClusterIP
   selector:
-    app: nodewatcher
+    app: nodewatcher-v1.5
   ports:
     - protocol: TCP
       port: 4466

--- a/back/node_watcher/kubernetes/v1.5/nomidotwatcher-job.yaml
+++ b/back/node_watcher/kubernetes/v1.5/nomidotwatcher-job.yaml
@@ -1,13 +1,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: nomidotwatcher-160366
+  name: nomidotwatcher
   namespace: nodewatcher-staging
   labels:
     stage: staging
     name: nomidotwatcher
     app: nomidotwatcher
-    job-name: nomidotwatcher-160366
+    job-name: nomidotwatcher
 spec:
   manualSelector: true
   selector:
@@ -15,14 +15,14 @@ spec:
       stage: staging
       name: nomidotwatcher
       app: nomidotwatcher
-      job-name: nomidotwatcher-160366
+      job-name: nomidotwatcher
   template:
     metadata:
       labels:
         stage: staging
         name: nomidotwatcher
         app: nomidotwatcher
-        job-name: nomidotwatcher-160366
+        job-name: nomidotwatcher
     spec:
       restartPolicy: Never
       containers:
@@ -33,5 +33,5 @@ spec:
             - name: PRISMA_ENDPOINT
               value: http://10.0.9.43:4466
             - name: START_FROM
-              value: '282000'
+              value: '0'
           command: ["yarn", "start"]


### PR DESCRIPTION
closes https://github.com/paritytech/Nomidot/issues/190

just tweaked the clouddb secret to point to a the db named v1.5

I'm not sure but I wonder if it's a problem to use the same 4466 port. so far the job is running though