### PR TITLE
Using our dedicated rpc-node

### DIFF
--- a/back/node_watcher/kubernetes/nomidotwatcher-last-50k-job.yaml
+++ b/back/node_watcher/kubernetes/nomidotwatcher-last-50k-job.yaml
@@ -32,6 +32,8 @@ spec:
           env:
             - name: PRISMA_ENDPOINT
               value: http://10.0.9.43:4466
+            - name: ARCHIVE_NODE_ENDPOINT
+              value: ws://polkassembly-rpc-internal-0.parity-prod.parity.io:9944
             - name: START_FROM
               value: '1305897'
             - name: BLOCK_IDENTIFIER


### PR DESCRIPTION
it didn't work with `wss` or without the port number FYI.
Last-50K is running with it now.