### PR TITLE
Fv dockerize in ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,8 +5,11 @@ stages:
   - dockerize
 
 variables:
-  GIT_DEPTH: '3'
-  SIMPLECOV: 'true'
+  GIT_DEPTH:      '3'
+  SIMPLECOV:      'true'
+  KUBE_NAMESPACE: "nomidot"
+  CI_REGISTRY:    "gcr.io/test-installations-222013"
+  DOCKER_TAG:     '$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA'
 
 cache:
   key: '${CI_JOB_NAME}'
@@ -29,7 +32,7 @@ linux-test:
 
 #### stage:                        dockerize
 
-.docker_init:                   &docker_init
+.dockerize_init:                   &dockerize_init
   variables:
     DOCKER_DRIVER: overlay2
     DOCKER_HOST: tcp://localhost:2375
@@ -45,11 +48,11 @@ linux-test:
     - echo $DOCKER_IMAGE_FULL_NAME
     - echo "$DOCKER_REGISTRY_JSON" | docker login -u _json_key --password-stdin https://gcr.io
 
-dockerize-nomidot-frontend:
+dockerize-frontend:
   stage: dockerize
   environment:
     name: parity-build
-  <<: *docker_init
+  <<: *dockerize_init
   script:
     - docker build -t "$DOCKER_IMAGE_FULL_NAME" front
     - docker push "$DOCKER_IMAGE_FULL_NAME"
@@ -57,11 +60,11 @@ dockerize-nomidot-frontend:
     - master
     - tags
 
-dockerize-nomidot-server:
+dockerize-server:
   stage: dockerize
   environment:
     name: parity-build
-  <<: *docker_init
+  <<: *dockerize_init
   script:
     - docker build -t "$DOCKER_IMAGE_FULL_NAME" back/server
     - docker push "$DOCKER_IMAGE_FULL_NAME"
@@ -73,7 +76,7 @@ dockerize-nodewatcher:
   stage: dockerize
   environment:
     name: parity-build
-  <<: *docker_init
+  <<: *dockerize_init
   script:
     - docker build -t "$DOCKER_IMAGE_FULL_NAME" back/node_watcher
     - docker push "$DOCKER_IMAGE_FULL_NAME"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,8 @@
+image: parity/kubetools:latest
+
 stages:
   - test
+  - dockerize
 
 variables:
   GIT_DEPTH: '3'
@@ -23,3 +26,57 @@ linux-test:
     - yarn lint
   tags:
     - linux-docker
+
+#### stage:                        dockerize
+
+.docker_init:                   &docker_init
+  variables:
+    DOCKER_DRIVER: overlay2
+    DOCKER_HOST: tcp://localhost:2375
+  tags:
+    - kubernetes-parity-build
+  image: docker:git
+  services:
+    - docker:dind
+  before_script:
+    - POD_NAME=$(echo ${CI_JOB_NAME} | sed -E 's/^[[:alnum:]:]+-//')
+    - export DOCKER_IMAGE="${CI_REGISTRY}/${KUBE_NAMESPACE}-${POD_NAME}"
+    - export DOCKER_IMAGE_FULL_NAME=$DOCKER_IMAGE:$DOCKER_TAG
+    - echo $DOCKER_IMAGE_FULL_NAME
+    - echo "$DOCKER_REGISTRY_JSON" | docker login -u _json_key --password-stdin https://gcr.io
+
+dockerize-nomidot-frontend:
+  stage: dockerize
+  environment:
+    name: parity-build
+  <<: *docker_init
+  script:
+    - docker build -t "$DOCKER_IMAGE_FULL_NAME" front
+    - docker push "$DOCKER_IMAGE_FULL_NAME"
+  only:
+    - master
+    - tags
+
+dockerize-nomidot-server:
+  stage: dockerize
+  environment:
+    name: parity-build
+  <<: *docker_init
+  script:
+    - docker build -t "$DOCKER_IMAGE_FULL_NAME" back/server
+    - docker push "$DOCKER_IMAGE_FULL_NAME"
+  only:
+    - master
+    - tags
+
+dockerize-nodewatcher:
+  stage: dockerize
+  environment:
+    name: parity-build
+  <<: *docker_init
+  script:
+    - docker build -t "$DOCKER_IMAGE_FULL_NAME" back/node_watcher
+    - docker push "$DOCKER_IMAGE_FULL_NAME"
+  only:
+    - master
+    - tags


### PR DESCRIPTION
Added a new stage (dockerize) to the CI, that builds new docker Images

On **master** and **tags** for
- frontend 
- server
- noder_watecher

And uploads them to the Google Container Registry in the *test-installations* project.

Builds on **master** are tagged as `:master-<short-commit-hash>` and tagged branches
are tagged as: `<tag-name>-<short-commit-hash>`.


