### PR TITLE
fix(context): Make provider optional in contexts

### DIFF
--- a/front/context/src/HealthContext.tsx
+++ b/front/context/src/HealthContext.tsx
@@ -39,15 +39,15 @@ export interface HealthContextType {
  * @param health - The health of the light node
  */
 function getNodeStatus(
-  provider: ProviderInterface,
-  header: Header | undefined,
-  health: Health | undefined
+  provider?: ProviderInterface,
+  header?: Header,
+  health?: Health
 ): Omit<HealthContextType, 'isSyncing'> {
   let best = 0;
   let isNodeConnected = false;
   let hasPeers = false;
 
-  if (provider.isConnected() && health && header) {
+  if (provider && provider.isConnected() && health && header) {
     isNodeConnected = true;
     best = header.number.toNumber();
 
@@ -69,7 +69,7 @@ export const HealthContext: React.Context<HealthContextType> = React.createConte
 
 export interface HealthContextProviderProps {
   children?: React.ReactElement;
-  provider: ProviderInterface;
+  provider?: ProviderInterface;
 }
 
 // Track if we we're already syncing
@@ -86,6 +86,10 @@ export function HealthContextProvider(
   // set isSyncing to true
   useEffect(() => {
     let timer: number | undefined;
+
+    if (!health) {
+      return;
+    }
 
     if (!wasSyncing && health.isSyncing.eq(true)) {
       wasSyncing = true;

--- a/front/context/src/SystemContext.tsx
+++ b/front/context/src/SystemContext.tsx
@@ -31,14 +31,14 @@ function distinctCodecChanged<T extends Codec>(): MonoTypeOperatorFunction<T> {
  * System-wide meta-information about the chain (nothing from its state)
  */
 export interface SystemContextType {
-  chain: Text;
-  genesisHash: BlockHash;
-  header: Header;
-  health: Health;
-  isSystemReady: boolean;
-  name: Text;
-  properties: ChainProperties;
-  version: Text;
+  chain?: Text;
+  genesisHash?: BlockHash;
+  header?: Header;
+  health?: Health;
+  isSystemReady?: boolean;
+  name?: Text;
+  properties?: ChainProperties;
+  version?: Text;
 }
 
 const l = logger('system-context');
@@ -49,7 +49,7 @@ export const SystemContext: React.Context<SystemContextType> = React.createConte
 
 export interface SystemContextProviderProps {
   children?: React.ReactElement;
-  provider: ProviderInterface;
+  provider?: ProviderInterface;
 }
 
 export function SystemContextProvider(
@@ -65,14 +65,22 @@ export function SystemContextProvider(
   const [version, setVersion] = useState<Text>();
 
   const registryRef = useRef(new TypeRegistry());
-  const [rpc, setRpc] = useState(new Rpc(registryRef.current, provider));
+  const [rpc, setRpc] = useState<Rpc>();
 
   useEffect(() => {
+    if (!provider) {
+      return;
+    }
+
     // Create a new RPC client each time we change provider
     setRpc(new Rpc(registryRef.current, provider));
   }, [provider]);
 
   useEffect(() => {
+    if (!provider || !rpc) {
+      return;
+    }
+
     // We want to fetch all the information again each time we reconnect. We
     // might be connecting to a different node, or the node might have changed
     // settings.
@@ -115,6 +123,10 @@ export function SystemContextProvider(
   }, [provider, rpc]);
 
   useEffect(() => {
+    if (!provider || !rpc) {
+      return;
+    }
+
     const sub = providerConnected(provider)
       .pipe(
         filter(connected => !!connected),
@@ -143,10 +155,10 @@ export function SystemContextProvider(
   return (
     <SystemContext.Provider
       value={{
-        chain: chain as Text,
-        genesisHash: genesisHash as BlockHash,
-        header: header as Header,
-        health: health as Health,
+        chain,
+        genesisHash,
+        header,
+        health,
         isSystemReady: !!(
           chain &&
           genesisHash &&
@@ -156,9 +168,9 @@ export function SystemContextProvider(
           properties &&
           version
         ),
-        name: name as Text,
-        properties: properties as ChainProperties,
-        version: version as Text,
+        name,
+        properties,
+        version,
       }}
     >
       {children}

--- a/front/context/src/SystemContext.tsx
+++ b/front/context/src/SystemContext.tsx
@@ -35,7 +35,7 @@ export interface SystemContextType {
   genesisHash?: BlockHash;
   header?: Header;
   health?: Health;
-  isSystemReady?: boolean;
+  isSystemReady: boolean;
   name?: Text;
   properties?: ChainProperties;
   version?: Text;


### PR DESCRIPTION
Making `provider` prop optional in Health and System contexts. I need this is light-ui, it shouldn't change behavior in nomidot.