### PR TITLE
fix(context): Reset context parameters when we change provider

### DIFF
--- a/front/context/src/HealthContext.tsx
+++ b/front/context/src/HealthContext.tsx
@@ -82,6 +82,15 @@ export function HealthContextProvider(
   const { header, health } = useContext(SystemContext);
   const [isSyncing, setIsSyncing] = useState(true);
 
+  // When we change provider, reset `isSyncing` to true
+  useEffect(() => {
+    if (!provider) {
+      return;
+    }
+
+    setIsSyncing(true);
+  }, [provider]);
+
   // We wait for 2 seconds, and if we've been syncing for 2 seconds, then we
   // set isSyncing to true
   useEffect(() => {

--- a/front/context/src/HealthContext.tsx
+++ b/front/context/src/HealthContext.tsx
@@ -84,10 +84,6 @@ export function HealthContextProvider(
 
   // When we change provider, reset `isSyncing` to true
   useEffect(() => {
-    if (!provider) {
-      return;
-    }
-
     setIsSyncing(true);
   }, [provider]);
 

--- a/front/context/src/SystemContext.tsx
+++ b/front/context/src/SystemContext.tsx
@@ -68,10 +68,6 @@ export function SystemContextProvider(
   const [rpc, setRpc] = useState<Rpc>();
 
   useEffect(() => {
-    if (!provider) {
-      return;
-    }
-
     // When we change provider, reset everything
     setChain(undefined);
     setGenesisHash(undefined);
@@ -80,6 +76,10 @@ export function SystemContextProvider(
     setName(undefined);
     setProperties(undefined);
     setVersion(undefined);
+
+    if (!provider) {
+      return;
+    }
 
     // Create a new RPC client each time we change provider
     setRpc(new Rpc(registryRef.current, provider));

--- a/front/context/src/SystemContext.tsx
+++ b/front/context/src/SystemContext.tsx
@@ -72,6 +72,15 @@ export function SystemContextProvider(
       return;
     }
 
+    // When we change provider, reset everything
+    setChain(undefined);
+    setGenesisHash(undefined);
+    setHeader(undefined);
+    setHealth(undefined);
+    setName(undefined);
+    setProperties(undefined);
+    setVersion(undefined);
+
     // Create a new RPC client each time we change provider
     setRpc(new Rpc(registryRef.current, provider));
   }, [provider]);


### PR DESCRIPTION
When we change provider, the Health & System contexts should show the values of the new provider. During the 2-3s transition period, show `undefined` instead of the old provider's value.

Tested on light-ui