### PR TITLE
chore: Bump everywhere to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.4.0](https://github.com/paritytech/Nomidot/compare/v0.3.25...v0.4.0) (2020-04-20)
+
+**Note:** Version bump only for package nomidot
+
+
+
+
+
 ## [0.3.25](https://github.com/paritytech/Nomidot/compare/v0.3.24...v0.3.25) (2020-04-20)
 
 

--- a/back/node_watcher/package.json
+++ b/back/node_watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/node-watcher",
-  "version": "0.3.25",
+  "version": "0.4.0",
   "author": "Parity Technologies <admin@parity.io>",
   "license": "Apache-2.0",
   "description": "Extract, Transform, Load Kusama/Polkadot history into a PostgreSQL DB",

--- a/front/context/CHANGELOG.md
+++ b/front/context/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.4.0](https://github.com/paritytech/Nomidot/compare/v0.3.25...v0.4.0) (2020-04-20)
+
+**Note:** Version bump only for package @substrate/context
+
+
+
+
+
 ## [0.3.25](https://github.com/paritytech/Nomidot/compare/v0.3.24...v0.3.25) (2020-04-20)
 
 

--- a/front/gatsby/CHANGELOG.md
+++ b/front/gatsby/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.4.0](https://github.com/paritytech/Nomidot/compare/v0.3.25...v0.4.0) (2020-04-20)
+
+**Note:** Version bump only for package @substrate/nomidot-gatsby
+
+
+
+
+
 ## [0.3.25](https://github.com/paritytech/Nomidot/compare/v0.3.24...v0.3.25) (2020-04-20)
 
 

--- a/front/gatsby/package.json
+++ b/front/gatsby/package.json
@@ -10,7 +10,7 @@
     "@apollo/react-hooks": "^3.1.3",
     "@loadable/component": "^5.12.0",
     "@polkadot/extension-dapp": "^0.21.1",
-    "@substrate/context": "^0.3.25",
+    "@substrate/context": "^0.4.0",
     "@substrate/design-system": "^1.0.9",
     "@substrate/ui-components": "^0.3.26",
     "@types/loadable__component": "^5.10.0",

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
     "back/*"
   ],
   "useWorkspaces": true,
-  "version": "0.3.25"
+  "version": "0.4.0"
 }


### PR DESCRIPTION
Follows https://github.com/paritytech/Nomidot/pull/307

Unfortunately the packages have been bumped to 0.3.25 in between (but not published), so the CHANGELOG's are a bit messed up.