### PR TITLE
fix(context): Don't instantiate API twice

### DIFF
--- a/front/context/src/ApiPromiseContext.tsx
+++ b/front/context/src/ApiPromiseContext.tsx
@@ -7,6 +7,7 @@ import { logger } from '@polkadot/util';
 import React, { useEffect, useState } from 'react';
 
 import { ApiRxContextProviderProps } from './types';
+import { useDidUpdateEffect } from './util';
 
 export interface ApiPromiseContextType {
   api: ApiPromise; // From @polkadot/api\
@@ -28,7 +29,7 @@ export function ApiPromiseContextProvider(
   );
   const [isReady, setIsReady] = useState(false);
 
-  useEffect(() => {
+  useDidUpdateEffect(() => {
     // We want to fetch all the information again each time we reconnect. We
     // might be connecting to a different node, or the node might have changed
     // settings.

--- a/front/context/src/ApiRxContext.tsx
+++ b/front/context/src/ApiRxContext.tsx
@@ -7,6 +7,7 @@ import { logger } from '@polkadot/util';
 import React, { useEffect, useState } from 'react';
 
 import { ApiRxContextProviderProps } from './types';
+import { useDidUpdateEffect } from './util';
 
 export interface ApiRxContextType {
   api: ApiRx; // From @polkadot/api\
@@ -26,7 +27,7 @@ export function ApiRxContextProvider(
   const [apiRx, setApiRx] = useState<ApiRx>(new ApiRx({ provider }));
   const [isReady, setIsReady] = useState(false);
 
-  useEffect(() => {
+  useDidUpdateEffect(() => {
     // We want to fetch all the information again each time we reconnect. We
     // might be connecting to a different node, or the node might have changed
     // settings.

--- a/front/context/src/util/index.ts
+++ b/front/context/src/util/index.ts
@@ -6,3 +6,4 @@ export * from './provider';
 export * from './ssr';
 export * from './stashes';
 export * from './ui';
+export * from './useEffect';

--- a/front/context/src/util/useEffect.ts
+++ b/front/context/src/util/useEffect.ts
@@ -1,0 +1,23 @@
+// Copyright 2018-2020 @paritytech/Nomidot authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
+
+/**
+ * Exactly like React's `useEffect`, but skips initial render. Tries to
+ * reproduce `componentDidUpdate` behavior.
+ *
+ * @see https://stackoverflow.com/questions/53179075/with-useeffect-how-can-i-skip-applying-an-effect-upon-the-initial-render/53180013#53180013
+ */
+export function useDidUpdateEffect(
+  fn: EffectCallback,
+  inputs?: DependencyList
+): void {
+  const didMountRef = useRef(false);
+
+  return useEffect(() => {
+    if (didMountRef.current) fn();
+    else didMountRef.current = true;
+  }, inputs);
+}


### PR DESCRIPTION
superseded #309 