### PR TITLE
fix(#313): gitlab for lerna bump and publish

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,32 +34,12 @@ linux-test:
 lerna-patch:
   stage: release
   script:
-    - yarn lerna:bump patch
+    - yarn lerna:bump
     - yarn lerna:publish 
   only:
     - master
     - tags
-    # - /^-release:patch.*$/
-
-lerna-minor:
-  stage: release
-  script:
-    - yarn lerna:bump minor
-    - yarn lerna:publish 
-  only:
-    - master
-    - tags
-    # - /^-release:minor.*$/
-
-lerna-major:
-  stage: release
-  script:
-    - yarn lerna:bump major
-    - yarn lerna:publish 
-  only:
-    - master
-    - tags
-    # - /^-release:major.*$/
+    # - ^\w.*-release.*$
 
 #### stage:                        dockerize
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,8 +38,7 @@ lerna-patch:
     - yarn lerna:publish 
   only:
     - master
-    - tags
-    # - ^\w.*-release-patch.*$
+    # - /^\w.*-release-patch.*$/
 
 lerna-minor:
   stage: release
@@ -48,8 +47,7 @@ lerna-minor:
     - yarn lerna:publish 
   only:
     - master
-    - tags
-    # - ^\w.*-release-minor.*$
+    # - /^\w.*-release-minor.*$/
 
 lerna-major:
   stage: release
@@ -58,8 +56,7 @@ lerna-major:
     - yarn lerna:publish 
   only:
     - master
-    - tags
-    # - ^\w.*-release-major.*$
+    # - /^\w.*-release-major.*$/
 
 #### stage:                        dockerize
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,12 +34,32 @@ linux-test:
 lerna-patch:
   stage: release
   script:
-    - yarn lerna:bump
+    - yarn lerna:bump patch
     - yarn lerna:publish 
   only:
     - master
     - tags
-    # - ^\w.*-release.*$
+    # - ^\w.*-release-patch.*$
+
+lerna-minor:
+  stage: release
+  script:
+    - yarn lerna:bump minor
+    - yarn lerna:publish 
+  only:
+    - master
+    - tags
+    # - ^\w.*-release-minor.*$
+
+lerna-major:
+  stage: release
+  script:
+    - yarn lerna:bump major
+    - yarn lerna:publish 
+  only:
+    - master
+    - tags
+    # - ^\w.*-release-major.*$
 
 #### stage:                        dockerize
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ image: parity/kubetools:latest
 
 stages:
   - test
+  - release
   - dockerize
 
 variables:
@@ -29,6 +30,36 @@ linux-test:
     - yarn lint
   tags:
     - linux-docker
+
+lerna-patch:
+  stage: release
+  script:
+    - yarn lerna:bump patch
+    - yarn lerna:publish 
+  only:
+    - master
+    - tags
+    # - /^-release:patch.*$/
+
+lerna-minor:
+  stage: release
+  script:
+    - yarn lerna:bump minor
+    - yarn lerna:publish 
+  only:
+    - master
+    - tags
+    # - /^-release:minor.*$/
+
+lerna-major:
+  stage: release
+  script:
+    - yarn lerna:bump major
+    - yarn lerna:publish 
+  only:
+    - master
+    - tags
+    # - /^-release:major.*$/
 
 #### stage:                        dockerize
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "yarn clean && lerna run build --stream --scope @substrate/context --scope @substrate/node-watcher --scope @substrate/nomidot-server --scope @substrate/nomidot-gatsby",
     "netlify": "cd front/gatsby && yarn build",
     "clean": "rimraf front/**/lib back/**/lib front/**/.cache back/**/.cache",
-    "lerna:bump": "lerna version --conventional-commits",
+    "lerna:bump": "lerna version",
     "lerna:publish": "yarn build && lerna publish from-git",
     "lint": "tsc --noEmit && node --max_old_space_size=8192 ./node_modules/eslint/bin/eslint.js --ext js,ts,tsx .",
     "start": "cd ./front/gatsby && yarn start",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2788,11 +2788,6 @@
     resolve-from "^5.0.0"
     ts-dedent "^1.1.0"
 
-"@substrate/context@^0.3.25":
-  version "0.4.0"
-  dependencies:
-    "@substrate/local-storage" "^2.2.9"
-
 "@substrate/design-system@^1.0.9":
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/@substrate/design-system/-/design-system-1.0.13.tgz#abd739a72489ce2925614061e82613ed6624b6ef"


### PR DESCRIPTION
addressing #313 

add a stage in CI to run `lerna version bump --conventional-commits && lerna publish`  on merge to master of any PR on a branch name ending with `-release` 