### PR TITLE
set externalTrafficPolicy to local

### DIFF
--- a/back/server/kubernetes/loadbalancer.yaml
+++ b/back/server/kubernetes/loadbalancer.yaml
@@ -9,6 +9,7 @@ metadata:
     app: nomidot-staging
 spec:
   loadBalancerIP: 35.189.196.74
+  externalTrafficPolicy: Local
   type: LoadBalancer
   selector:
     app: nomidot-server


### PR DESCRIPTION
this will fix the issue of ws connection not properly terminated after a restart of *nomidot-server* pods