### PR TITLE
feat: v1.5 sync config

### DIFF
--- a/back/node_watcher/kubernetes/v1.5/nodewatcher-deployment-staging.yaml
+++ b/back/node_watcher/kubernetes/v1.5/nodewatcher-deployment-staging.yaml
@@ -5,12 +5,12 @@ metadata:
   namespace: nodewatcher-staging
   labels:
     stage: staging
-    name:  nodewatcher-v1.5
-    app:  nodewatcher-v1.5
+    name: nodewatcher-v1.5
+    app: nodewatcher-v1.5
 spec:
   selector:
     matchLabels:
-      app:  nodewatcher-v1.5
+      app: nodewatcher-v1.5
   replicas: 1
   strategy:
     type: RollingUpdate
@@ -18,8 +18,8 @@ spec:
     metadata:
       labels:
         stage: staging
-        name:  nodewatcher-v1.5
-        app:  nodewatcher-v1.5
+        name: nodewatcher-v1.5
+        app: nodewatcher-v1.5
     spec:
       containers:
         - name: prisma
@@ -28,11 +28,11 @@ spec:
             - name: prisma-4466
               containerPort: 4466
           env:
-            - name: PRISMA_CONFIG
+            - name: PRISMA_CONFIG_v1.5
               valueFrom:
                 secretKeyRef:
-                  name: prisma-config
-                  key: prisma-config
+                  name: prisma-config-v1.5
+                  key: prisma-config-v1.5
             - name: DB_USER
               valueFrom:
                 secretKeyRef:

--- a/back/node_watcher/kubernetes/v1.5/nomidotwatcher-job.yaml
+++ b/back/node_watcher/kubernetes/v1.5/nomidotwatcher-job.yaml
@@ -27,7 +27,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: nomidotwatcher
-          image: eu.gcr.io/test-installations-222013/nomidot_watcher@sha256:23dfc5a9638f00e5b3cac05abe46b59bf7f69f108f2974eb880a88e89bab66bb
+          image: eu.gcr.io/test-installations-222013/nomidot_watcher@sha256:f88f02e79cfc2c5a8f59ab2fae50f26eda40f1bd7ee4cc8c8b07b194c11d2cee
           imagePullPolicy: Always
           env:
             - name: PRISMA_ENDPOINT

--- a/back/node_watcher/kubernetes/v1.5/nomidotwatcher-last-50k-job.yaml
+++ b/back/node_watcher/kubernetes/v1.5/nomidotwatcher-last-50k-job.yaml
@@ -27,7 +27,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: nomidotwatcher
-          image: eu.gcr.io/test-installations-222013/nomidot_watcher@sha256:23dfc5a9638f00e5b3cac05abe46b59bf7f69f108f2974eb880a88e89bab66bb
+          image: eu.gcr.io/test-installations-222013/nomidot_watcher@sha256:f88f02e79cfc2c5a8f59ab2fae50f26eda40f1bd7ee4cc8c8b07b194c11d2cee
           imagePullPolicy: Always
           env:
             - name: PRISMA_ENDPOINT
@@ -35,7 +35,7 @@ spec:
             - name: ARCHIVE_NODE_ENDPOINT
               value: ws://polkassembly-rpc-internal-0.parity-prod.parity.io:9944
             - name: START_FROM
-              value: '1100000'
+              value: '2008791'
             - name: BLOCK_IDENTIFIER
               value: 'last-50k-1.5'
             - name: MAX_LAG


### PR DESCRIPTION
not included in this PR is the updated prisma config secret.

viewable by: `kubectl get secrets prisma-config-v1.5 -o yaml -n nodewatcher-staging`
decode with: `"echo {output from above} | base64 --decode"`

```
port: 4466
databases:
  v1-5:
    connector: postgres
    host: 127.0.0.1
    user: DB_ADMIN
    password: DB_PASSWORD
    rawAccess: true
    port: 5432
    migrations: true
    connectionLimit: 8
```

this is almost exactly the same as with v1 that's been syncing. importantly `default` was changed to v1-5 matching the `dbname` in our gcloud sql project. https://console.cloud.google.com/sql/instances/kusama-etl/databases?project=test-installations-222013

while this uses the same port 4466, the `nodewatcher-v1.5` deployment gets assigned its own ClusterIP so it shouldn't matter.