### PR TITLE
Move node watcher task to cloud function

### DIFF
--- a/back/node_watcher/docker-compose.yml
+++ b/back/node_watcher/docker-compose.yml
@@ -2,18 +2,19 @@ version: '3.7'
 services:
   main:
     build: ./
-  postgres:
-    image: postgres:12.1
-    restart: always
-    ports:
-      - '5432:5432'
-    environment:
-      POSTGRES_USER: prisma
-      POSTGRES_PASSWORD: prisma
-    volumes:
-      - postgres:/var/lib/postgresql/data
+  # postgres:
+  #   image: postgres:12.1
+  #   restart: always
+  #   ports:
+  #     - '5432:5432'
+  #   environment:
+  #     POSTGRES_USER: prisma
+  #     POSTGRES_PASSWORD: prisma
+  #   volumes:
+  #     - postgres:/var/lib/postgresql/data
   prisma:
     image: prismagraphql/prisma:1.34
+    network_mode: "host"
     restart: always
     ports:
       - '4466:4466'
@@ -24,8 +25,8 @@ services:
           default:
             connector: postgres
             host: postgres
-            user: prisma
-            password: prisma
+            user: postgres
+            password: postgres
             rawAccess: true
             port: 5432
             migrations: true

--- a/back/node_watcher/package.json
+++ b/back/node_watcher/package.json
@@ -23,11 +23,15 @@
     "build": "tsc",
     "docker": "cp ../../yarn.lock . && docker build -t nomidot_watcher:v1.2.32 . && docker tag nomidot_watcher:v1.2.32 eu.gcr.io/test-installations-222013/nomidot_watcher:v1.2.32 && docker push eu.gcr.io/test-installations-222013/nomidot_watcher:v1.2.32 && rm yarn.lock",
     "local": "BLOCK_IDENTIFIER=0 START_FROM=0 PRISMA_ENDPOINT=http://127.0.0.1:4466 yarn start",
-    "start": "node -r ts-node/register --max-old-space-size=8192 ./src/index.ts"
+    "start": "node -r ts-node/register --max-old-space-size=8192 ./src/index.ts",
+    "start:runner": "node -r ts-node/register --max-old-space-size=8192 ./src/taskRunner.ts"
   },
   "dependencies": {
     "@polkadot/api": "^1.9.1",
     "@types/bn.js": "^4.11.6",
+    "@types/node-fetch": "^2.5.7",
+    "express": "^4.17.1",
+    "node-fetch": "^2.6.0",
     "p-retry": "^4.2.0",
     "prisma-client-lib": "1.34.10"
   },

--- a/back/node_watcher/src/taskRunner.ts
+++ b/back/node_watcher/src/taskRunner.ts
@@ -1,0 +1,107 @@
+// Copyright 2018-2020 @paritytech/nomidot authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { getSpecTypes } from '@polkadot/types-known';
+import { BlockNumber, Hash } from '@polkadot/types/interfaces';
+import { logger } from '@polkadot/util';
+import bodyParser from 'body-parser';
+import express, { Request, Response } from 'express';
+
+import { nomidotTasks } from './tasks';
+import { Cached } from './tasks/types';
+
+const l = logger('node-watcher');
+
+const ARCHIVE_NODE_ENDPOINT =
+  process.env.ARCHIVE_NODE_ENDPOINT || 'wss://kusama-rpc.polkadot.io/';
+
+const runTask = async (blockIndex: number): Promise<void> => {
+  const provider = new WsProvider(ARCHIVE_NODE_ENDPOINT);
+  const api = await ApiPromise.create({ provider });
+
+  let currentSpecVersion = api.createType('u32', -1);
+
+  const blockNumber: BlockNumber = api.createType('BlockNumber', blockIndex);
+  l.warn(`block: ${blockNumber}`);
+
+  const blockHash: Hash = await api.rpc.chain.getBlockHash(blockNumber);
+  l.warn(`hash: ${blockHash}`);
+
+  // check spec version
+  const runtimeVersion = await api.rpc.state.getRuntimeVersion(blockHash);
+  const newSpecVersion = runtimeVersion.specVersion;
+
+  // if spec version was bumped, update metadata in api registry
+  if (newSpecVersion.gt(currentSpecVersion)) {
+    l.warn(`bumped spec version to ${newSpecVersion}, fetching new metadata`);
+    const rpcMeta = await api.rpc.state.getMetadata(blockHash);
+    currentSpecVersion = newSpecVersion;
+
+    // based on the node spec & chain, inject specific type overrides
+    const chain = await api.rpc.system.chain();
+    api.registry.register(
+      getSpecTypes(
+        api.registry,
+        chain,
+        runtimeVersion.specName,
+        runtimeVersion.specVersion
+      )
+    );
+    api.registry.setMetadata(rpcMeta);
+  }
+
+  const [events, sessionIndex] = await Promise.all([
+    await api.query.system.events.at(blockHash),
+    await api.query.session.currentIndex.at(blockHash),
+  ]);
+
+  const cached: Cached = {
+    events,
+    sessionIndex,
+  };
+
+  // execute watcher tasks
+  for await (const task of nomidotTasks) {
+    l.warn(`Task --- ${task.name}`);
+
+    const result = await task.read(blockHash, cached, api);
+
+    try {
+      l.warn(`Writing: ${JSON.stringify(result)}`);
+      await task.write(blockNumber, result);
+    } catch (e) {
+      // Write task might throw errors such as unique constraints violated,
+      // we ignore those.
+      l.error(e);
+    }
+  }
+};
+
+export const taskRunner = (req: Request, res: Response): void => {
+  console.log(req.body.blockIndex);
+  runTask(req.body.blockIndex)
+    .then(() => {
+      res.json({
+        result: 'success',
+      });
+    })
+    .catch(error => {
+      res.status(500).json({
+        error: error.message,
+      });
+    });
+};
+
+if (require.main === module) {
+  const app = express();
+
+  app.use(bodyParser.json());
+  app.use('/runtask', taskRunner);
+
+  app.listen(Number(process.env.PORT), () => {
+    console.log(`App is running at http://localhost:${process.env.PORT}`);
+    console.log('Press CTRL-C to stop\n');
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3116,6 +3116,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/node-fetch@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
+  integrity sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*", "@types/node@>= 8", "@types/node@>=6", "@types/node@^13.7.4":
   version "13.11.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.1.tgz#49a2a83df9d26daacead30d0ccc8762b128d53c7"
@@ -6022,7 +6030,7 @@ columnify@^1.5.4:
     strip-ansi "^3.0.0"
     wcwidth "^1.0.0"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -9091,6 +9099,15 @@ form-data@^2.0.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
 form-data@~2.3.2:


### PR DESCRIPTION
Possible solution for memory leak: https://github.com/paritytech/Nomidot/issues/267

We can move running task read write part to cloud function (https://cloud.google.com/functions). Cloud function are serverless compute instances which starts and tears down for each invokation. So memory leak issue will not arise. 

Long running script will just invoke cloud function with blockIndex.

To test on local:

Start task runner/cloud function:
```
ARCHIVE_NODE_ENDPOINT=ws://127.0.0.1:9944 PRISMA_ENDPOINT=http://0.0.0.0:4466 PORT=4489 yarn start:runner
```

Start long running loop:
```
MAX_LAG=5 BLOCK_IDENTIFIER=aasdsdasdadssa ARCHIVE_NODE_ENDPOINT=ws://127.0.0.1:9944 TASK_RUNNER_SERVER=http://localhost:4489 PRISMA_ENDPOINT=http://0.0.0.0:4466 yarn start
```

long running loop will invoke cloud function with incrementing blockIndex. Cloud function will execute and tear down releasing memory. Invokation rate will be at the speed of block production.