### PR TITLE
added ingress controler for nodewatcher server

### DIFF
--- a/back/server/kubernetes/nodewatcher-server-ingress.yaml
+++ b/back/server/kubernetes/nodewatcher-server-ingress.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: nodewatcher-server-ingress
+  labels:
+    app: nodewatcher-server
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.frontend.entryPoints: "https,http"
+spec:
+  rules:
+  - host: test.nodewatcher-server.polkassembly.io
+    http:
+      paths:
+      - backend:
+          serviceName: nodewatcher-server
+          servicePort: 4000
+        path: /

--- a/back/server/kubernetes/nodewatcher-server-service.yaml
+++ b/back/server/kubernetes/nodewatcher-server-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nodewatcher-server
+  name: nodewatcher-server
+spec:
+  ports:
+  - name: nodewatcher-server
+    port: 4000
+    protocol: TCP
+  selector:
+    app: nomidot-server
+  type: ClusterIP


### PR DESCRIPTION
This change adds a new service + ingress controller to make the nodewatcher/nomidot server available from outside the *dashboards-cluster-1* via the url: `https://test.nodewatcher-server.polkassembly.io`.

This new service offers the same functionality as the existing `Nomidot/back/server/kubernetes/loadbalancer.yaml`, but looks like being more reliably handling web-socket connections.