### PR TITLE
fix: cart page nomination UX

### DIFF
--- a/front/context/src/AccountsContext.tsx
+++ b/front/context/src/AccountsContext.tsx
@@ -349,16 +349,16 @@ export function AccountsContextProvider(props: Props): React.ReactElement {
     }
   }, []);
 
-  // const fetchCachedUserSession = useCallback((): void => {
-  //   const cachedAccount = localStorage.getItem('currentAccount');
+  const fetchCachedUserSession = useCallback((): void => {
+    const cachedAccount = localStorage.getItem('currentAccount');
 
-  //   if (cachedAccount !== null) {
-  //     dispatch({
-  //       type: 'setCurrentAccount',
-  //       data: JSON.parse(cachedAccount),
-  //     });
-  //   }
-  // }, []);
+    if (cachedAccount !== null) {
+      dispatch({
+        type: 'setCurrentAccount',
+        data: JSON.parse(cachedAccount) as string
+      });
+    }
+  }, []);
 
   // set signer
   useEffect(() => {
@@ -428,7 +428,8 @@ export function AccountsContextProvider(props: Props): React.ReactElement {
   useEffect(() => {
     fetchAccounts();
     fetchCachedRpcResults();
-  }, [WINDOW_TYPE, fetchAccounts, fetchCachedRpcResults]);
+    fetchCachedUserSession();
+  }, [WINDOW_TYPE, fetchAccounts, fetchCachedRpcResults, fetchCachedUserSession]);
 
   useEffect(() => {
     if ((state.extension, state.isExtensionReady)) {
@@ -514,7 +515,7 @@ export function AccountsContextProvider(props: Props): React.ReactElement {
       });
       writeStorage(
         'currentAccount',
-        JSON.stringify(state.allAccounts[0].address)
+        state.allAccounts[0].address
       );
     }
   }, [state.allAccounts, state.currentAccount, state.isExtensionReady]);

--- a/front/context/src/AccountsContext.tsx
+++ b/front/context/src/AccountsContext.tsx
@@ -355,7 +355,7 @@ export function AccountsContextProvider(props: Props): React.ReactElement {
     if (cachedAccount !== null) {
       dispatch({
         type: 'setCurrentAccount',
-        data: JSON.parse(cachedAccount) as string
+        data: JSON.parse(cachedAccount) as string,
       });
     }
   }, []);
@@ -429,7 +429,12 @@ export function AccountsContextProvider(props: Props): React.ReactElement {
     fetchAccounts();
     fetchCachedRpcResults();
     fetchCachedUserSession();
-  }, [WINDOW_TYPE, fetchAccounts, fetchCachedRpcResults, fetchCachedUserSession]);
+  }, [
+    WINDOW_TYPE,
+    fetchAccounts,
+    fetchCachedRpcResults,
+    fetchCachedUserSession,
+  ]);
 
   useEffect(() => {
     if ((state.extension, state.isExtensionReady)) {
@@ -513,10 +518,7 @@ export function AccountsContextProvider(props: Props): React.ReactElement {
         type: 'setCurrentAccount',
         data: state.allAccounts[0].address,
       });
-      writeStorage(
-        'currentAccount',
-        state.allAccounts[0].address
-      );
+      writeStorage('currentAccount', state.allAccounts[0].address);
     }
   }, [state.allAccounts, state.currentAccount, state.isExtensionReady]);
 

--- a/front/gatsby/src/components/AccountsDropdown.tsx
+++ b/front/gatsby/src/components/AccountsDropdown.tsx
@@ -2,7 +2,6 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { InjectedAccountWithMeta } from '@polkadot/extension-inject/types';
 import { AccountsContext, getControllers } from '@substrate/context';
 import { Spinner } from '@substrate/design-system';
 import { InputAddress } from '@substrate/ui-components';
@@ -34,17 +33,19 @@ const AccountsDropdown = function(props: Props): React.ReactElement {
     return <Spinner inline active />;
   }
 
-  return  <InputAddress
-              accounts={
-                onlyControllers
-                  ? getControllers(allAccounts, stashControllerMap)
-                  : allAccounts
-              }
-              fromKeyring={false}
-              onChangeAddress={handleOnChangeAddress}
-              value={currentAccount}
-              width={width || '3rem'}
-            />
+  return (
+    <InputAddress
+      accounts={
+        onlyControllers
+          ? getControllers(allAccounts, stashControllerMap)
+          : allAccounts
+      }
+      fromKeyring={false}
+      onChangeAddress={handleOnChangeAddress}
+      value={currentAccount}
+      width={width || '3rem'}
+    />
+  );
 };
 
 export default AccountsDropdown;

--- a/front/gatsby/src/components/AccountsDropdown.tsx
+++ b/front/gatsby/src/components/AccountsDropdown.tsx
@@ -6,27 +6,19 @@ import { InjectedAccountWithMeta } from '@polkadot/extension-inject/types';
 import { AccountsContext, getControllers } from '@substrate/context';
 import { Spinner } from '@substrate/design-system';
 import { InputAddress } from '@substrate/ui-components';
-import React, { memo, useCallback, useContext, useEffect, useMemo, useState } from 'react';
-
-import { ClosableTooltip, SubHeader, Text } from './index';
+import React, { useCallback, useContext } from 'react';
 
 interface Props {
   onlyControllers: boolean; // filter only controllers
+  width?: string;
 }
 
 const AccountsDropdown = function(props: Props): React.ReactElement {
-  const { onlyControllers } = props;
+  const { onlyControllers, width } = props;
   const {
     state: { allAccounts, currentAccount, stashControllerMap },
     dispatch,
   } = useContext(AccountsContext);
-  const [controllers, setControllers] = useState<InjectedAccountWithMeta[]>();
-
-  useEffect(() => {
-    const controls = getControllers(allAccounts, stashControllerMap);
-    console.log(controls);
-    setControllers(controls);
-  }, [allAccounts, onlyControllers, stashControllerMap]);
 
   const handleOnChangeAddress = useCallback(
     (address: string): void => {
@@ -42,32 +34,17 @@ const AccountsDropdown = function(props: Props): React.ReactElement {
     return <Spinner inline active />;
   }
 
-  if (onlyControllers && !controllers) {
-    return <Spinner inline active />
-  }
-
-  if (!controllers!.length) {
-    return (
-      <ClosableTooltip>
-        <SubHeader>You need a Controller Account to submit a Nomination!</SubHeader>
-        <Text>No Controller accounts found. Go to Accounts page to create an Controller.</Text>
-      </ClosableTooltip>
-    )
-  }
-
-  return (
-    <InputAddress
-      accounts={
-        onlyControllers
-          ? controllers
-          : allAccounts
-      }
-      fromKeyring={false}
-      onChangeAddress={handleOnChangeAddress}
-      value={controllers ? controllers[0].address : currentAccount}
-      width='3rem'
-    />
-  );
+  return  <InputAddress
+              accounts={
+                onlyControllers
+                  ? getControllers(allAccounts, stashControllerMap)
+                  : allAccounts
+              }
+              fromKeyring={false}
+              onChangeAddress={handleOnChangeAddress}
+              value={currentAccount}
+              width={width || '3rem'}
+            />
 };
 
-export default memo(AccountsDropdown);
+export default AccountsDropdown;

--- a/front/gatsby/src/components/Cart/CartItems.tsx
+++ b/front/gatsby/src/components/Cart/CartItems.tsx
@@ -7,7 +7,6 @@ import {
   Icon,
   List,
   Margin,
-  Stacked,
   StackedHorizontal,
   WithSpaceAround,
 } from '@substrate/ui-components';
@@ -15,8 +14,7 @@ import { navigate } from 'gatsby';
 import React, { useContext } from 'react';
 
 import { removeCartItem } from '../../util/cartHelpers';
-import { AddressSummary } from '../index';
-import { Button, SubHeader } from '../index';
+import { AddressSummary, Button, SubHeader, Text, Tooltip } from '../index';
 
 interface Props {
   cartItems: string[];
@@ -30,17 +28,18 @@ const CartItems = (props: Props): React.ReactElement => {
 
   const renderCartEmpty = (): React.ReactElement => {
     return (
-      <Stacked>
+      <Tooltip>
         <SubHeader>Cart Empty</SubHeader>
-        <p>you should add some validators to nominate...</p>
+        <Text>you should add some validators to nominate...</Text>
         <Button
           neutral
           size='big'
+          float='right'
           onClick={(): Promise<void> => navigate('/validators')}
         >
           Take Me There!
         </Button>
-      </Stacked>
+      </Tooltip>
     );
   };
 

--- a/front/gatsby/src/components/Layout/Header/Header.tsx
+++ b/front/gatsby/src/components/Layout/Header/Header.tsx
@@ -12,7 +12,12 @@ import styled from 'styled-components';
 import media from 'styled-media-query';
 
 import { APP_TITLE } from '../../../util';
-import { BlockHeader } from './Subheaders';
+import {
+  BlockHeader,
+  EraHeader,
+  SessionHeader,
+  StakingHeader,
+} from './Subheaders';
 
 type Props = RouteComponentProps;
 
@@ -49,13 +54,12 @@ const NavLink = styled(Link)`
 `;
 
 const LinkArea = styled.div`
-  margin: 0 45rem 0 0;
+  margin: 0 30rem 0 0;
 `;
 
 const CartIcon = styled.div`
   color: white;
   display: flex;
-  flex: 1 1 auto;
   align-items: center;
   justify-content: center;
   height: 50px;
@@ -79,10 +83,6 @@ const Logo = styled.h2`
   ${media.lessThan('small')`
     margin-right: 3rem;
   `}
-`;
-
-const BlockCounter = styled(BlockHeader)`
-  flex: 2 1 auto;
 `;
 
 const ExtensionStatus = styled.p`
@@ -111,7 +111,11 @@ export default function Header(_props: Props): React.ReactElement {
           <NavLink to='/accounts'>Accounts</NavLink>
           <NavLink to='/validators'>Validators</NavLink>
         </LinkArea>
-        <BlockCounter />
+
+        <StakingHeader />
+        <EraHeader />
+        <SessionHeader />
+        <BlockHeader />
         {!extensionNotFound && (
           <CartIcon>
             <Icon link name='cart' size='large' onClick={navToCartPage} />

--- a/front/gatsby/src/components/Layout/Layout.tsx
+++ b/front/gatsby/src/components/Layout/Layout.tsx
@@ -3,7 +3,9 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { RouteComponentProps } from '@reach/router';
-import React from 'react';
+import { ApiRxContext } from '@substrate/context';
+import { Loading } from '@substrate/ui-components';
+import React, { useContext } from 'react';
 
 import { LoadableHeader } from './Header';
 
@@ -13,11 +15,16 @@ interface Props extends RouteComponentProps {
 
 export function Layout(props: Props): React.ReactElement {
   const { children } = props;
+  const { isApiReady } = useContext(ApiRxContext);
 
   return (
     <>
       <LoadableHeader {...props} />
-      {children}
+      {
+        isApiReady
+          ? children
+          : <Loading active /> 
+        }
     </>
   );
 }

--- a/front/gatsby/src/components/Layout/Layout.tsx
+++ b/front/gatsby/src/components/Layout/Layout.tsx
@@ -20,11 +20,7 @@ export function Layout(props: Props): React.ReactElement {
   return (
     <>
       <LoadableHeader {...props} />
-      {
-        isApiReady
-          ? children
-          : <Loading active /> 
-        }
+      {isApiReady ? children : <Loading active />}
     </>
   );
 }

--- a/front/gatsby/src/components/NominationDetails.tsx
+++ b/front/gatsby/src/components/NominationDetails.tsx
@@ -84,10 +84,7 @@ export const NominationDetails = (props: Props): React.ReactElement => {
             title='Nomination Amount: '
             value={`${formatBalance(nominationAmount)}`}
           />
-          <StatItem
-            title='Txn Fees: '
-            value={`${formatBalance(allFees)}`}
-          />
+          <StatItem title='Txn Fees: ' value={`${formatBalance(allFees)}`} />
         </DivItemMulti>
       </Div>
 
@@ -96,7 +93,7 @@ export const NominationDetails = (props: Props): React.ReactElement => {
         <DivItemMulti>
           <StatItem title='Rate' value={rate ? rate.toString() : '0'} />
           <StatItem
-            title='Value'
+            title='Your estimated rewards from this era'
             value={estimatedReward ? formatBalance(estimatedReward) : '0'}
           />
         </DivItemMulti>

--- a/front/gatsby/src/components/NominationDetails.tsx
+++ b/front/gatsby/src/components/NominationDetails.tsx
@@ -19,37 +19,35 @@ const ContentArea = styled.div`
   padding: 2rem;
 `;
 
-const SummaryDiv = styled.div`
+const Div = styled.div`
   display: flex column;
   justify-content: space-around;
   align-items: flex-start;
 `;
 
-const SummaryDivItem = styled.div`
+const DivItem = styled.div`
   flex: 1;
   margin: 4px 3px;
   padding: 7px 0;
 `;
 
-const EstimationDiv = styled.div`
+const DivItemMulti = styled.div`
+  flex: 1;
   display: flex;
-  justify-content: space-around;
   margin: 4px 3px;
+  justify-content: space-around;
+  align-items: flex-start;
   padding: 7px 0;
-
-  > h2 {
-    flex: 1;
-    margin: 0;
-  }
 `;
 
 interface Props {
+  allFees?: BN;
   impliedStash?: string;
   nominationAmount?: BN;
 }
 
 export const NominationDetails = (props: Props): React.ReactElement => {
-  const { impliedStash, nominationAmount } = props;
+  const { allFees, impliedStash, nominationAmount } = props;
   const { bondingDuration } = useContext(ApiRxContext);
   const [estimatedReward, setEstimatedReward] = useState<BN>();
   const [rate, setRate] = useState<number>();
@@ -66,33 +64,43 @@ export const NominationDetails = (props: Props): React.ReactElement => {
 
   return (
     <ContentArea>
-      <SummaryDiv>
-        <SummaryDivItem>
+      <Div>
+        <DivItem>
           <StatItem title='Nominate with Controller: '>
             <AccountsDropdown onlyControllers />
           </StatItem>
-        </SummaryDivItem>
-        <SummaryDivItem>
+        </DivItem>
+        <DivItem>
           <StatItem title='Implied Stash: '>
             {impliedStash ? impliedStash : <Spinner active inline />}
           </StatItem>
-        </SummaryDivItem>
-        <SummaryDivItem>
+        </DivItem>
+        <DivItemMulti>
           <StatItem
             title='Bonding Duration: '
             value={`${bondingDuration} eras`}
           />
-        </SummaryDivItem>
-      </SummaryDiv>
+          <StatItem
+            title='Nomination Amount: '
+            value={`${formatBalance(nominationAmount)}`}
+          />
+          <StatItem
+            title='Txn Fees: '
+            value={`${formatBalance(allFees)}`}
+          />
+        </DivItemMulti>
+      </Div>
 
       <SubHeader>Estimated Rewards: </SubHeader>
-      <EstimationDiv>
-        <StatItem title='Rate' value={rate ? rate.toString() : '0'} />
-        <StatItem
-          title='Value'
-          value={estimatedReward ? formatBalance(estimatedReward) : '0'}
-        />
-      </EstimationDiv>
+      <Div>
+        <DivItemMulti>
+          <StatItem title='Rate' value={rate ? rate.toString() : '0'} />
+          <StatItem
+            title='Value'
+            value={estimatedReward ? formatBalance(estimatedReward) : '0'}
+          />
+        </DivItemMulti>
+      </Div>
     </ContentArea>
   );
 };

--- a/front/gatsby/src/components/NominationDetails.tsx
+++ b/front/gatsby/src/components/NominationDetails.tsx
@@ -58,7 +58,7 @@ export const NominationDetails = (props: Props): React.ReactElement => {
     if (nominationAmount) {
       // FIXME
       const rate = calcRewards();
-      
+
       setRate(rate);
       setEstimatedReward(nominationAmount.muln(rate));
     }

--- a/front/gatsby/src/components/Tooltip.tsx
+++ b/front/gatsby/src/components/Tooltip.tsx
@@ -33,13 +33,15 @@ const Close = styled(Icon)`
 `;
 
 interface ClosableTooltipProps {
+  height?: string;
+  width?: string;
   children: React.ReactNode;
 }
 
 export const ClosableTooltip = (
   props: ClosableTooltipProps
 ): React.ReactElement => {
-  const { children } = props;
+  const { children, height, width } = props;
   const [closeTooltip, setCloseTooltip] = useState(false);
 
   const handleClose = useCallback(() => {
@@ -47,7 +49,7 @@ export const ClosableTooltip = (
   }, []);
 
   return (
-    <Tooltip closed={closeTooltip}>
+    <Tooltip closed={closeTooltip} height={height} width={width}>
       <Close name='close' onClick={handleClose} />
       <TooltipContent>{children}</TooltipContent>
     </Tooltip>

--- a/front/gatsby/src/components/Tooltip.tsx
+++ b/front/gatsby/src/components/Tooltip.tsx
@@ -19,7 +19,8 @@ export const Tooltip = styled.div<TooltipProps>`
   width: ${(props): string => props.width || '100%'};
   display: ${(props): string => (props.closed ? 'none' : 'inline-block')};
 
-  > div, p {
+  > div,
+  p {
     padding: 5px 18px;
   }
 `;

--- a/front/gatsby/src/components/Tooltip.tsx
+++ b/front/gatsby/src/components/Tooltip.tsx
@@ -12,16 +12,16 @@ interface TooltipProps {
   width?: string;
 }
 
-const Tooltip = styled.div<TooltipProps>`
+export const Tooltip = styled.div<TooltipProps>`
   background: #f2f4f6;
   border-radius: 3px;
   height: ${(props): string => props.height || '50%'};
   width: ${(props): string => props.width || '100%'};
   display: ${(props): string => (props.closed ? 'none' : 'inline-block')};
-`;
 
-const TooltipContent = styled.div`
-  padding: 8px 18px;
+  > div, p {
+    padding: 5px 18px;
+  }
 `;
 
 const Close = styled(Icon)`
@@ -51,7 +51,7 @@ export const ClosableTooltip = (
   return (
     <Tooltip closed={closeTooltip} height={height} width={width}>
       <Close name='close' onClick={handleClose} />
-      <TooltipContent>{children}</TooltipContent>
+      {children}
     </Tooltip>
   );
 };

--- a/front/gatsby/src/pages/cart.tsx
+++ b/front/gatsby/src/pages/cart.tsx
@@ -153,7 +153,15 @@ const Cart = (_props: Props): React.ReactElement => {
       const id = enqueue(extrinsic, details);
       setTxId(id);
     }
-  }, [api, allFees, allTotal, currentAccount, extrinsic, enqueue, nominationAmount]);
+  }, [
+    api,
+    allFees,
+    allTotal,
+    currentAccount,
+    extrinsic,
+    enqueue,
+    nominationAmount,
+  ]);
 
   useEffect(() => {
     if (txId !== undefined && !isSubmitted) {

--- a/front/gatsby/src/pages/cart.tsx
+++ b/front/gatsby/src/pages/cart.tsx
@@ -27,6 +27,7 @@ import {
   NominationDetails,
   SubHeader,
   Text,
+  Tooltip
 } from '../components';
 import { getCartItems, validateFees } from '../util';
 import { clearCart, stripAddressFromCartItem } from '../util/cartHelpers';
@@ -62,6 +63,10 @@ const RightSide = styled.div`
 
   > a {
     float: right;
+  }
+
+  > div {
+    margin: 10px;
   }
 `;
 
@@ -231,7 +236,7 @@ const Cart = (_props: Props): React.ReactElement => {
       </LeftSide>
 
       <RightSide>
-        <ClosableTooltip height='25%'>
+        <ClosableTooltip height='200px'>
           <SubHeader>Before you continue...</SubHeader>
           <Text>
             You are submitting the <b>intention</b> to nominate these accounts
@@ -261,13 +266,13 @@ const Cart = (_props: Props): React.ReactElement => {
             )}
           </>
         ) : (
-          <>
+          <Tooltip height='100px'>
             <SubHeader>Please come back later.</SubHeader>
             <Text>
               You cannot submit a nomination while there is an ongoing election
               for the next era validator set.
             </Text>
-          </>
+          </Tooltip>
         )}
       </RightSide>
     </CartPageContainer>

--- a/front/gatsby/src/pages/cart.tsx
+++ b/front/gatsby/src/pages/cart.tsx
@@ -73,7 +73,7 @@ const RightSide = styled.div`
 type Props = RouteComponentProps;
 
 /*
- * N.b. Wwhatever amount is Bonded to the Controller is the amount that will be nominated. There is no way to nominate a fraction of the bond.
+ * N.b. Whatever amount is Bonded to the Controller is the amount that will be nominated. There is no way to nominate a fraction of the bond.
  */
 const Cart = (_props: Props): React.ReactElement => {
   /* context */
@@ -254,6 +254,7 @@ const Cart = (_props: Props): React.ReactElement => {
               <SubHeader>Review Details: </SubHeader>
             </HeadingDiv>
             <NominationDetails
+              allFees={allFees}
               impliedStash={impliedStash}
               nominationAmount={nominationAmount && nominationAmount.toBn()}
             />

--- a/front/gatsby/src/pages/cart.tsx
+++ b/front/gatsby/src/pages/cart.tsx
@@ -27,7 +27,7 @@ import {
   NominationDetails,
   SubHeader,
   Text,
-  Tooltip
+  Tooltip,
 } from '../components';
 import { getCartItems, validateFees } from '../util';
 import { clearCart, stripAddressFromCartItem } from '../util/cartHelpers';

--- a/front/gatsby/src/util/validateExtrinsic.ts
+++ b/front/gatsby/src/util/validateExtrinsic.ts
@@ -20,7 +20,7 @@ type Errors = Error[];
 
 /**
  * Make sure derived validations (fees, minimal amount) are correct.
- * @see https://github.com/polkadot-js/apps/blob/master/packages/ui-signer/src/Checks/index.tsx#L63-L111
+ * @see https://github.com/polkadot-js/apps/tree/master/packages/react-signer
  */
 export function validateFees(
   accountNonce: AccountInfo,
@@ -41,10 +41,14 @@ export function validateFees(
   const allTotal = amount
     .add(allFees)
     .add(isCreation ? fees.creationFee : new BN(0));
-  const hasAvailable = currentBalance.freeBalance.gte(allTotal);
-  const isRemovable = currentBalance.votingBalance
+
+  const hasAvailable = extrinsic.method.methodName === 'transfer' ? currentBalance.freeBalance.gte(allTotal) : true;
+
+  // Other activities that may lock up the funds are permitted
+  const isRemovable = extrinsic.method.methodName === 'transfer' ? currentBalance.votingBalance
     .sub(allTotal)
-    .lte(fees.existentialDeposit);
+    .lte(fees.existentialDeposit) : false;
+
   const overLimit = txLength >= MAX_SIZE_BYTES;
   const errors = [] as Errors;
 

--- a/front/gatsby/src/util/validateExtrinsic.ts
+++ b/front/gatsby/src/util/validateExtrinsic.ts
@@ -42,12 +42,16 @@ export function validateFees(
     .add(allFees)
     .add(isCreation ? fees.creationFee : new BN(0));
 
-  const hasAvailable = extrinsic.method.methodName === 'transfer' ? currentBalance.freeBalance.gte(allTotal) : true;
+  const hasAvailable =
+    extrinsic.method.methodName === 'transfer'
+      ? currentBalance.freeBalance.gte(allTotal)
+      : true;
 
   // Other activities that may lock up the funds are permitted
-  const isRemovable = extrinsic.method.methodName === 'transfer' ? currentBalance.votingBalance
-    .sub(allTotal)
-    .lte(fees.existentialDeposit) : false;
+  const isRemovable =
+    extrinsic.method.methodName === 'transfer'
+      ? currentBalance.votingBalance.sub(allTotal).lte(fees.existentialDeposit)
+      : false;
 
   const overLimit = txLength >= MAX_SIZE_BYTES;
   const errors = [] as Errors;


### PR DESCRIPTION
`api.tx.staking.nominate` is signed by the controller, and whatever is the `activeBond` in the signing account is used as the nomination amount.

So this PR is removing the input amount, using the active bond of the selected account to estimate rewards and also adding tooltips to explain this, as well as the unbonding period.

also doing some refactoring

all this information from the docs for `api.tx.staking.nominate` needs to be communicated somehow:
       * Declare the desire to nominate `targets` for the origin controller.
       * Effects will be felt at the beginning of the next era. This can only be called when
       * [`EraElectionStatus`] is `Closed`.
       * The dispatch origin for this call must be _Signed_ by the controller, not the stash.
       * And, it can be only called when [`EraElectionStatus`] is `Closed`.