### PR TITLE
fix(context): Reset syncing to true when chaning provider

### DIFF
--- a/front/context/src/HealthContext.tsx
+++ b/front/context/src/HealthContext.tsx
@@ -72,7 +72,8 @@ export interface HealthContextProviderProps {
   provider?: ProviderInterface;
 }
 
-// Track if we we're already syncing
+// Track if we we're already syncing. Initialize to true, if the not is not
+// syncing, then it'll be changed to false.
 let wasSyncing = true;
 
 export function HealthContextProvider(
@@ -84,6 +85,7 @@ export function HealthContextProvider(
 
   // When we change provider, reset `isSyncing` to true
   useEffect(() => {
+    wasSyncing = true;
     setIsSyncing(true);
   }, [provider]);
 


### PR DESCRIPTION
Subtle bug: when in light-ui I'm changing providers: if the old provider was syncing or not syncing, it should not have any effect on the syncing status of the new provider