### PR TITLE
chore(node-watcher): Don't publish package

### DIFF
--- a/back/node_watcher/package.json
+++ b/back/node_watcher/package.json
@@ -15,9 +15,7 @@
     "Postgres",
     "Polkadot"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "repository": "https://github.com/paritytech/Nomidot",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
got error while publishing

```
lerna info publish Publishing packages to npm...
lerna info Verifying npm credentials
lerna http fetch GET 200 https://registry.npmjs.org/-/npm/v1/user 1893ms
lerna http fetch GET 200 https://registry.npmjs.org/-/org/amaurymartiny/package?format=cli 1045ms
lerna info Checking two-factor auth mode
lerna http fetch GET 200 https://registry.npmjs.org/-/npm/v1/user 563ms
lerna http fetch PUT 400 https://registry.npmjs.org/@substrate%2fnode-watcher 7092ms
lerna ERR! E400 This package contains unacceptable content. Contact support@npmjs.com.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

so I just thought of not publishing anymore. We can re-publish it later, when it's more stable? Alternatively, figure out what is unacceptable content (maybe the Dockerfile?)